### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,26 +12,30 @@ branches:
 matrix:
     fast_finish: true
     include:
+        - php: 7.3
+        - php: 7.2
         - php: 7.1
         - php: 7.0
         - php: 5.6
         - php: 5.5
+          dist: trusty
         - php: 5.5
+          dist: trusty
           env: SYMFONY_VERSION=2.7.*
         - php: 5.5
+          dist: trusty
           env: SYMFONY_VERSION=2.8.*
         - php: 5.5
+          dist: trusty
           env: SYMFONY_VERSION=3.0.*
         - php: 5.5
+          dist: trusty
           env: PREDIS_VERSION=1.0.*
         - php: 5.5
+          dist: trusty
           env: PREDIS_VERSION=1.1.*
         - php: 5.6
           env: PUBSUB_PREDIS_VERSION=2.0.*
-        - php: hhvm
-          sudo: required
-          dist: trusty
-          group: edge
 
 before_install:
     - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then echo 'xdebug.enable = on' >> /etc/hhvm/php.ini; fi

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "symfony/dependency-injection": "~2.3|~3.0",
         "symfony/serializer": "~2.3|~3.0",
         "predis/predis": "~1.0|~1.1",
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "^4.8.36",
         "scrutinizer/ocular": "~1.3",
-        "satooshi/php-coveralls": "^1.0"
+        "php-coveralls/php-coveralls": "^1.0"
     }
 }

--- a/tests/Command/Bus/HandlerLocatedCommandBusTest.php
+++ b/tests/Command/Bus/HandlerLocatedCommandBusTest.php
@@ -13,8 +13,9 @@ namespace GpsLab\Component\Tests\Command\Bus;
 use GpsLab\Component\Command\Bus\HandlerLocatedCommandBus;
 use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Handler\Locator\CommandHandlerLocator;
+use PHPUnit\Framework\TestCase;
 
-class HandlerLocatedCommandBusTest extends \PHPUnit_Framework_TestCase
+class HandlerLocatedCommandBusTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|CommandHandlerLocator

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Command\Command;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\Handler\CreateContactHandler;
 use Psr\Container\ContainerInterface;
+use PHPUnit\Framework\TestCase;
 
-class ContainerCommandHandlerLocatorTest extends \PHPUnit_Framework_TestCase
+class ContainerCommandHandlerLocatorTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -12,8 +12,9 @@ namespace GpsLab\Component\Tests\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 use GpsLab\Component\Command\Command;
+use PHPUnit\Framework\TestCase;
 
-class DirectBindingCommandHandlerLocatorTest extends \PHPUnit_Framework_TestCase
+class DirectBindingCommandHandlerLocatorTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Command

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Command\Command;
 use GpsLab\Component\Tests\Fixture\Command\Handler\RenameContactHandler;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use PHPUnit\Framework\TestCase;
 
-class SymfonyContainerCommandHandlerLocatorTest extends \PHPUnit_Framework_TestCase
+class SymfonyContainerCommandHandlerLocatorTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface

--- a/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
@@ -13,8 +13,9 @@ namespace GpsLab\Component\Tests\Command\Queue\Pull;
 use GpsLab\Component\Command\Queue\Pull\MemoryPullCommandQueue;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
+use PHPUnit\Framework\TestCase;
 
-class MemoryPullCommandQueueTest extends \PHPUnit_Framework_TestCase
+class MemoryPullCommandQueueTest extends TestCase
 {
     /**
      * @var MemoryPullCommandQueue

--- a/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
@@ -13,8 +13,9 @@ namespace GpsLab\Component\Tests\Command\Queue\Pull;
 use GpsLab\Component\Command\Queue\Pull\MemoryUniquePullCommandQueue;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
+use PHPUnit\Framework\TestCase;
 
-class MemoryUniquePullCommandQueueTest extends \PHPUnit_Framework_TestCase
+class MemoryUniquePullCommandQueueTest extends TestCase
 {
     /**
      * @var MemoryUniquePullCommandQueue

--- a/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
@@ -16,8 +16,9 @@ use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use Predis\Client;
 use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
 
-class PredisPullCommandQueueTest extends \PHPUnit_Framework_TestCase
+class PredisPullCommandQueueTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Client

--- a/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
@@ -16,8 +16,9 @@ use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use Predis\Client;
 use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
 
-class PredisUniquePullCommandQueueTest extends \PHPUnit_Framework_TestCase
+class PredisUniquePullCommandQueueTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Client

--- a/tests/Command/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Command/Queue/Serializer/SymfonySerializerTest.php
@@ -13,8 +13,9 @@ namespace  GpsLab\Component\Tests\Command\Queue\Serializer;
 use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Queue\Serializer\SymfonySerializer;
 use Symfony\Component\Serializer\SerializerInterface;
+use PHPUnit\Framework\TestCase;
 
-class SymfonySerializerTest extends \PHPUnit_Framework_TestCase
+class SymfonySerializerTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|SerializerInterface

--- a/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
@@ -12,8 +12,9 @@ namespace GpsLab\Component\Tests\Command\Queue\Subscribe;
 
 use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Queue\Subscribe\ExecutingSubscribeCommandQueue;
+use PHPUnit\Framework\TestCase;
 
-class ExecutingSubscribeCommandQueueTest extends \PHPUnit_Framework_TestCase
+class ExecutingSubscribeCommandQueueTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Command

--- a/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Command\Queue\Serializer\Serializer;
 use GpsLab\Component\Command\Queue\Subscribe\PredisSubscribeCommandQueue;
 use Psr\Log\LoggerInterface;
 use Superbalist\PubSub\Redis\RedisPubSubAdapter;
+use PHPUnit\Framework\TestCase;
 
-class PredisSubscribeCommandQueueTest extends \PHPUnit_Framework_TestCase
+class PredisSubscribeCommandQueueTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Command
@@ -181,6 +182,7 @@ class PredisSubscribeCommandQueueTest extends \PHPUnit_Framework_TestCase
         $handler = function ($command) use ($exception) {
             $this->assertInstanceOf(Command::class, $command);
             $this->assertEquals($this->command, $command);
+
             throw $exception;
         };
 

--- a/tests/Query/Bus/HandlerLocatedQueryBusTest.php
+++ b/tests/Query/Bus/HandlerLocatedQueryBusTest.php
@@ -13,8 +13,9 @@ namespace GpsLab\Component\Tests\Query\Bus;
 use GpsLab\Component\Query\Bus\HandlerLocatedQueryBus;
 use GpsLab\Component\Query\Query;
 use GpsLab\Component\Query\Handler\Locator\QueryHandlerLocator;
+use PHPUnit\Framework\TestCase;
 
-class HandlerLocatedQueryBusTest extends \PHPUnit_Framework_TestCase
+class HandlerLocatedQueryBusTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|QueryHandlerLocator

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Query\Query;
 use GpsLab\Component\Tests\Fixture\Query\ContactByIdentity;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContactByIdentityHandler;
 use Psr\Container\ContainerInterface;
+use PHPUnit\Framework\TestCase;
 
-class ContainerQueryHandlerLocatorTest extends \PHPUnit_Framework_TestCase
+class ContainerQueryHandlerLocatorTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface

--- a/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
@@ -12,8 +12,9 @@ namespace GpsLab\Component\Tests\Query\Handler\Locator;
 
 use GpsLab\Component\Query\Handler\Locator\DirectBindingQueryHandlerLocator;
 use GpsLab\Component\Query\Query;
+use PHPUnit\Framework\TestCase;
 
-class DirectBindingQueryHandlerLocatorTest extends \PHPUnit_Framework_TestCase
+class DirectBindingQueryHandlerLocatorTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Query

--- a/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Query\Query;
 use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContactByNameHandler;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use PHPUnit\Framework\TestCase;
 
-class SymfonyContainerQueryHandlerLocatorTest extends \PHPUnit_Framework_TestCase
+class SymfonyContainerQueryHandlerLocatorTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface


### PR DESCRIPTION
# Changed log
- Add `php-7.2` and `php-7.3` tests during Travis CI build.
- To be compatible with future `PHPUnit` versions, using the `PHPUnit\Framework\TestCase` class namesapce instead.
- `satooshi/php-coveralls` package is deprecated and using the `php-coveralls/php-coveralls` instead.
- Removing the `hhvm` version test because it will not be different from future PHP versions.