### PR TITLE
Optimize use assert*() method in tests

### DIFF
--- a/tests/Command/Bus/HandlerLocatedCommandBusTest.php
+++ b/tests/Command/Bus/HandlerLocatedCommandBusTest.php
@@ -56,7 +56,7 @@ class HandlerLocatedCommandBusTest extends TestCase
         ;
 
         $this->bus->handle($this->command);
-        $this->assertEquals($this->command, $handled_command);
+        $this->assertSame($this->command, $handled_command);
     }
 
     public function testNoHandler()

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -44,7 +44,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
     {
         $this->command = $this->createMock(Command::class);
         $this->handler = function (Command $command) {
-            $this->assertEquals($command, $this->command);
+            $this->assertSame($command, $this->command);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new ContainerCommandHandlerLocator($this->container);
@@ -64,11 +64,11 @@ class ContainerCommandHandlerLocatorTest extends TestCase
         $this->locator->registerService(get_class($this->command), $service);
 
         $handler = $this->locator->findHandler($this->command);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($this->command);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testFindHandlerServiceInvoke()
@@ -88,15 +88,15 @@ class ContainerCommandHandlerLocatorTest extends TestCase
         $this->locator->registerService(CreateContact::class, $service, $method);
 
         $handler = $this->locator->findHandler($command);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($command);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
         call_user_func($handler, $command);
-        $this->assertEquals($command, $handler_obj->command());
+        $this->assertSame($command, $handler_obj->command());
     }
 
     public function testNoCommandHandler()

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -36,7 +36,7 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
     {
         $this->command = $this->createMock(Command::class);
         $this->handler = function (Command $command) {
-            $this->assertEquals($command, $this->command);
+            $this->assertSame($command, $this->command);
         };
         $this->locator = new DirectBindingCommandHandlerLocator();
     }
@@ -46,7 +46,7 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
         $this->locator->registerHandler(get_class($this->command), $this->handler);
 
         $handler = $this->locator->findHandler($this->command);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testNoCommandHandler()

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -44,7 +44,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
     {
         $this->command = $this->createMock(Command::class);
         $this->handler = function (Command $command) {
-            $this->assertEquals($command, $this->command);
+            $this->assertSame($command, $this->command);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new SymfonyContainerCommandHandlerLocator();
@@ -65,11 +65,11 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $this->locator->registerService(get_class($this->command), $service);
 
         $handler = $this->locator->findHandler($this->command);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($this->command);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testFindHandlerServiceInvoke()
@@ -90,15 +90,15 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $this->locator->registerService(RenameContactCommand::class, $service, $method);
 
         $handler = $this->locator->findHandler($command);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($command);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
         call_user_func($handler, $command);
-        $this->assertEquals($command, $handler_obj->command());
+        $this->assertSame($command, $handler_obj->command());
     }
 
     public function testNoCommandHandler()

--- a/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
@@ -42,10 +42,10 @@ class MemoryPullCommandQueueTest extends TestCase
         $expected = array_reverse($queue);
         $i = count($expected);
         while ($command = $this->queue->pull()) {
-            $this->assertEquals($expected[--$i], $command);
+            $this->assertSame($expected[--$i], $command);
         }
 
-        $this->assertEquals(0, $i, 'Queue cleared');
+        $this->assertSame(0, $i, 'Queue cleared');
         $this->assertNull($command, 'No commands in queue');
     }
 }

--- a/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
@@ -51,7 +51,7 @@ class MemoryUniquePullCommandQueueTest extends TestCase
             $this->assertEquals($expected[--$i], $command);
         }
 
-        $this->assertEquals(0, $i, 'Queue cleared');
+        $this->assertSame(0, $i, 'Queue cleared');
         $this->assertNull($command, 'No commands in queue');
     }
 }

--- a/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
@@ -124,10 +124,10 @@ class PredisPullCommandQueueTest extends TestCase
         $expected = array_reverse($queue);
         $i = count($expected);
         while ($command = $this->queue->pull()) {
-            $this->assertEquals($expected[--$i], $command);
+            $this->assertSame($expected[--$i], $command);
         }
 
-        $this->assertEquals(0, $i, 'Queue cleared');
+        $this->assertSame(0, $i, 'Queue cleared');
         $this->assertNull($command, 'No commands in queue');
     }
 

--- a/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
@@ -138,10 +138,10 @@ class PredisUniquePullCommandQueueTest extends TestCase
         $expected = array_reverse($queue);
         $i = count($expected);
         while ($command = $this->queue->pull()) {
-            $this->assertEquals($expected[--$i], $command);
+            $this->assertSame($expected[--$i], $command);
         }
 
-        $this->assertEquals(0, $i, 'Queue cleared');
+        $this->assertSame(0, $i, 'Queue cleared');
         $this->assertNull($command, 'No commands in queue');
     }
 

--- a/tests/Command/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Command/Queue/Serializer/SymfonySerializerTest.php
@@ -59,7 +59,7 @@ class SymfonySerializerTest extends TestCase
 
         $serializer = new SymfonySerializer($this->serializer, $format);
 
-        $this->assertEquals($result, $serializer->serialize($data));
+        $this->assertSame($result, $serializer->serialize($data));
     }
 
     /**
@@ -82,6 +82,6 @@ class SymfonySerializerTest extends TestCase
 
         $serializer = new SymfonySerializer($this->serializer, $format);
 
-        $this->assertEquals($result, $serializer->deserialize($data));
+        $this->assertSame($result, $serializer->deserialize($data));
     }
 }

--- a/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
@@ -38,7 +38,7 @@ class ExecutingSubscribeCommandQueueTest extends TestCase
         $subscriber_called = false;
         $handler = function ($command) use (&$subscriber_called) {
             $this->assertInstanceOf(Command::class, $command);
-            $this->assertEquals($this->command, $command);
+            $this->assertSame($this->command, $command);
             $subscriber_called = true;
         };
 

--- a/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
@@ -98,7 +98,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $subscriber_called = false;
         $handler = function ($command) use (&$subscriber_called) {
             $this->assertInstanceOf(Command::class, $command);
-            $this->assertEquals($this->command, $command);
+            $this->assertSame($this->command, $command);
             $subscriber_called = true;
         };
 
@@ -106,8 +106,8 @@ class PredisSubscribeCommandQueueTest extends TestCase
             ->expects($this->once())
             ->method('subscribe')
             ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
-                $this->assertEquals($this->queue_name, $queue_name);
-                $this->assertTrue(is_callable($handler_wrapper));
+                $this->assertSame($this->queue_name, $queue_name);
+                $this->assertIsCallable($handler_wrapper);
 
                 $message = 'foo';
                 $this->serializer
@@ -131,7 +131,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $subscriber_called = false;
         $handler = function ($command) use (&$subscriber_called) {
             $this->assertInstanceOf(Command::class, $command);
-            $this->assertEquals($this->command, $command);
+            $this->assertSame($this->command, $command);
             $subscriber_called = true;
         };
 
@@ -139,8 +139,8 @@ class PredisSubscribeCommandQueueTest extends TestCase
             ->expects($this->once())
             ->method('subscribe')
             ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
-                $this->assertEquals($this->queue_name, $queue_name);
-                $this->assertTrue(is_callable($handler_wrapper));
+                $this->assertSame($this->queue_name, $queue_name);
+                $this->assertIsCallable($handler_wrapper);
 
                 $exception = new \Exception('bar');
                 $message = 'foo';
@@ -182,7 +182,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $exception = new \Exception('bar');
         $handler = function ($command) use ($exception) {
             $this->assertInstanceOf(Command::class, $command);
-            $this->assertEquals($this->command, $command);
+            $this->assertSame($this->command, $command);
 
             throw $exception;
         };
@@ -191,8 +191,8 @@ class PredisSubscribeCommandQueueTest extends TestCase
             ->expects($this->once())
             ->method('subscribe')
             ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
-                $this->assertEquals($this->queue_name, $queue_name);
-                $this->assertTrue(is_callable($handler_wrapper));
+                $this->assertSame($this->queue_name, $queue_name);
+                $this->assertIsCallable($handler_wrapper);
 
                 $message = 'foo';
                 $this->serializer
@@ -213,7 +213,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
     {
         $handler1 = function ($command) {
             $this->assertInstanceOf(Command::class, $command);
-            $this->assertEquals($this->command, $command);
+            $this->assertSame($this->command, $command);
         };
         $handler2 = function (Command $command) {
         };

--- a/tests/Query/Bus/HandlerLocatedQueryBusTest.php
+++ b/tests/Query/Bus/HandlerLocatedQueryBusTest.php
@@ -43,7 +43,7 @@ class HandlerLocatedQueryBusTest extends TestCase
     {
         $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
-            $this->assertEquals($this->query, $query);
+            $this->assertSame($this->query, $query);
         };
         $this->locator = $this->createMock(QueryHandlerLocator::class);
         $this->bus = new HandlerLocatedQueryBus($this->locator);
@@ -65,8 +65,8 @@ class HandlerLocatedQueryBusTest extends TestCase
             ->will($this->returnValue($handler))
         ;
 
-        $this->assertEquals($data, $this->bus->handle($this->query));
-        $this->assertEquals($this->query, $handled_query);
+        $this->assertSame($data, $this->bus->handle($this->query));
+        $this->assertSame($this->query, $handled_query);
     }
 
     public function testNoHandler()

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -44,7 +44,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
     {
         $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
-            $this->assertEquals($query, $this->query);
+            $this->assertSame($query, $this->query);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new ContainerQueryHandlerLocator($this->container);
@@ -64,11 +64,11 @@ class ContainerQueryHandlerLocatorTest extends TestCase
         $this->locator->registerService(get_class($this->query), $service);
 
         $handler = $this->locator->findHandler($this->query);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($this->query);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testFindHandlerServiceInvoke()
@@ -88,15 +88,15 @@ class ContainerQueryHandlerLocatorTest extends TestCase
         $this->locator->registerService(ContactByIdentity::class, $service, $method);
 
         $handler = $this->locator->findHandler($query);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($query);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
         call_user_func($handler, $query);
-        $this->assertEquals($query, $handler_obj->query());
+        $this->assertSame($query, $handler_obj->query());
     }
 
     public function testNoQueryHandler()

--- a/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
@@ -36,7 +36,7 @@ class DirectBindingQueryHandlerLocatorTest extends TestCase
     {
         $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
-            $this->assertEquals($query, $this->query);
+            $this->assertSame($query, $this->query);
         };
         $this->locator = new DirectBindingQueryHandlerLocator();
     }
@@ -46,7 +46,7 @@ class DirectBindingQueryHandlerLocatorTest extends TestCase
         $this->locator->registerHandler(get_class($this->query), $this->handler);
 
         $handler = $this->locator->findHandler($this->query);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testNoQueryHandler()

--- a/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
@@ -44,7 +44,7 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
     {
         $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
-            $this->assertEquals($query, $this->query);
+            $this->assertSame($query, $this->query);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new SymfonyContainerQueryHandlerLocator();
@@ -65,11 +65,11 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
         $this->locator->registerService(get_class($this->query), $service);
 
         $handler = $this->locator->findHandler($this->query);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($this->query);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testFindHandlerServiceInvoke()
@@ -90,15 +90,15 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
         $this->locator->registerService(ContactByNameQuery::class, $service, $method);
 
         $handler = $this->locator->findHandler($query);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($query);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
         call_user_func($handler, $query);
-        $this->assertEquals($query, $handler_obj->query());
+        $this->assertSame($query, $handler_obj->query());
     }
 
     public function testNoQueryHandler()


### PR DESCRIPTION
Optimize use `assert*()` method in tests.

Change `assertEquals()` to `assertSame()`.

Change
```php
$this->assertTrue(is_callable(...));
```
to
```php
$this->assertIsCallable(...);
```