### PR TITLE
Not use a call_user_func() function

### DIFF
--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -95,7 +95,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
         $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
-        call_user_func($handler, $command);
+        $handler($command);
         $this->assertSame($command, $handler_obj->command());
     }
 

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -97,7 +97,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
-        call_user_func($handler, $command);
+        $handler($command);
         $this->assertSame($command, $handler_obj->command());
     }
 

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -95,7 +95,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
         $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
-        call_user_func($handler, $query);
+        $handler($query);
         $this->assertSame($query, $handler_obj->query());
     }
 


### PR DESCRIPTION
Not use a `call_user_func()` function.
`$handler($command);` would make more sense here (it also faster).