### PR TITLE
Add Command and Query subscribers

### DIFF
--- a/docs/command/locator/direct_binding.md
+++ b/docs/command/locator/direct_binding.md
@@ -29,7 +29,7 @@ class ArticleCommandSubscriber implements CommandSubscriber
     public static function getSubscribedCommands(): array
     {
         return [
-            RenameArticleCommand::class => 'handleRename'
+            RenameArticleCommand::class => 'handleRename',
         ];
     }
 

--- a/docs/command/locator/direct_binding.md
+++ b/docs/command/locator/direct_binding.md
@@ -19,6 +19,34 @@ $locator->registerHandler(RenameArticleCommand::class, $handler);
 
 More examples of binding in the section [Create handler](../handler.md).
 
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ArticleCommandSubscriber implements CommandSubscriber
+{
+    public static function getSubscribedCommands(): array
+    {
+        return [
+            RenameArticleCommand::class => 'handleRename'
+        ];
+    }
+
+    public function handleRename(RenameArticleCommand $command): void
+    {
+        // do something
+    }
+}
+
+// register command subscriber in handler locator
+$subscriber = new ArticleCommandSubscriber();
+$locator = new DirectBindingCommandHandlerLocator();
+$locator->registerSubscriber($subscriber);
+```
+
+## Problem
+
 The main problem with this locator is that you do not have the ability to implement a lazy load of the dependencies for
 this handler. The second problem is the need to explicitly register all handlers, even if you need to handle only one
 command at a run time.

--- a/docs/command/locator/psr-11_container.md
+++ b/docs/command/locator/psr-11_container.md
@@ -15,8 +15,8 @@ $handler = static function (RenameArticleCommand $command): void {
     // do something
 };
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.command.handler.article.rename') must return $handler
+// example of register handler in PSR-11 container
+// container on request $container->get('acme.demo.command.handler.article.rename') must return handler
 //$container = new Container();
 //$container->set('acme.demo.command.handler.article.rename', $handler);
 
@@ -38,8 +38,8 @@ class RenameArticleHandler
     }
 }
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.command.handler.article.rename') must return $handler
+// example of register handler in PSR-11 container
+// container on request $container->get('acme.demo.command.handler.article.rename') must return handler
 //$container = new Container();
 //$container->set('acme.demo.command.handler.article.rename', new RenameArticleHandler());
 
@@ -61,8 +61,8 @@ class RenameArticleHandler
     }
 }
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.command.handler.article.rename') must return $handler
+// example of register handler in PSR-11 container
+// container on request $container->get('acme.demo.command.handler.article.rename') must return handler
 //$container = new Container();
 //$container->set('acme.demo.command.handler.article.rename', new RenameArticleHandler());
 
@@ -81,7 +81,7 @@ class ArticleCommandSubscriber implements CommandSubscriber
     public static function getSubscribedCommands(): array
     {
         return [
-            RenameArticleCommand::class => 'handleRename'
+            RenameArticleCommand::class => 'handleRename',
         ];
     }
 
@@ -91,8 +91,8 @@ class ArticleCommandSubscriber implements CommandSubscriber
     }
 }
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.command.handler.article.rename') must return $handler
+// example of register subscriber in PSR-11 container
+// container on request $container->get('acme.demo.command.handler.article.rename') must return subscriber
 //$container = new Container();
 //$container->set('acme.demo.command.subscriber.article', new ArticleCommandSubscriber());
 

--- a/docs/command/locator/psr-11_container.md
+++ b/docs/command/locator/psr-11_container.md
@@ -70,3 +70,33 @@ class RenameArticleHandler
 $locator = new ContainerCommandHandlerLocator($container);
 $locator->registerService(RenameArticleCommand::class, 'acme.demo.command.handler.article.rename', 'handleRenameArticle');
 ```
+
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ArticleCommandSubscriber implements CommandSubscriber
+{
+    public static function getSubscribedCommands(): array
+    {
+        return [
+            RenameArticleCommand::class => 'handleRename'
+        ];
+    }
+
+    public function handleRename(RenameArticleCommand $command): void
+    {
+        // do something
+    }
+}
+
+// example of registr handler in PSR-11 container
+// container on request $container->get('acme.demo.command.handler.article.rename') must return $handler
+//$container = new Container();
+//$container->set('acme.demo.command.subscriber.article', new ArticleCommandSubscriber());
+
+// register command handler service in handler locator
+$locator = new ContainerCommandHandlerLocator($container);
+$locator->registerSubscriberService('acme.demo.command.subscriber.article', ArticleCommandSubscriber::class);
+```

--- a/docs/command/locator/symfony_container.md
+++ b/docs/command/locator/symfony_container.md
@@ -64,7 +64,64 @@ services:
             - [ registerService, [ 'RenameArticleCommand', 'RenameArticleHandler', 'handleRenameArticle' ] ]
 ```
 
-> **Note**
->
-> You can [tagged](https://symfony.com/doc/current/service_container/tags.html) command handler services for optimize
-> register the services in command locator.
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ArticleCommandSubscriber implements CommandSubscriber
+{
+    public static function getSubscribedCommands(): array
+    {
+        return [
+            RenameArticleCommand::class => 'handleRename'
+        ];
+    }
+
+    public function handleRename(RenameArticleCommand $command): void
+    {
+        // do something
+    }
+}
+```
+
+YAML configuration for this:
+
+```yml
+services:
+    ArticleCommandSubscriber: ~
+
+    GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator:
+        calls:
+            - [ setContainer, [ '@service_container' ] ]
+            - [ registerSubscriberService, [ 'ArticleCommandSubscriber', 'ArticleCommandSubscriber' ] ]
+```
+
+## Tagging
+
+You can [tagged](https://symfony.com/doc/current/service_container/tags.html) command handler services for optimize
+register the services in command locator. You can autoconfigure your subscribers and automatically register it in
+locator like that:
+
+```php
+// src/Kernel.php
+class Kernel extends BaseKernel
+{
+    protected function build(ContainerBuilder $container): void
+    {
+        $container
+            ->registerForAutoconfiguration(CommandSubscriber::class)
+            ->addTag('gpslab.command.subscriber')
+        ;
+
+        $locator = $container->findDefinition(SymfonyContainerCommandHandlerLocator::class);
+
+        $tagged_subscribers = $container->findTaggedServiceIds('gpslab.command.subscriber');
+
+        foreach ($tagged_subscribers as $id => $attributes) {
+            $subscriber = $container->findDefinition($id);
+            $locator->addMethodCall('registerSubscriberService', [$id, $subscriber->getClass()]);
+        }
+    }
+}
+```

--- a/docs/command/locator/symfony_container.md
+++ b/docs/command/locator/symfony_container.md
@@ -74,7 +74,7 @@ class ArticleCommandSubscriber implements CommandSubscriber
     public static function getSubscribedCommands(): array
     {
         return [
-            RenameArticleCommand::class => 'handleRename'
+            RenameArticleCommand::class => 'handleRename',
         ];
     }
 

--- a/docs/query/locator/direct_binding.md
+++ b/docs/query/locator/direct_binding.md
@@ -19,6 +19,34 @@ $locator->registerHandler(ContactByNameQuery::class, $handler);
 
 More examples of binding in the section [Create handler](../handler.md).
 
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ContactQuerySubscriber implements QuerySubscriber
+{
+    public static function getSubscribedQueries(): array
+    {
+        return [
+            ContactByNameQuery::class => 'getByNameQuery',
+        ];
+    }
+
+    public function getByNameQuery(ContactByNameQuery $query)
+    {
+        // return some data
+    }
+}
+
+// register command subscriber in handler locator
+$subscriber = new ContactQuerySubscriber();
+$locator = new DirectBindingQueryHandlerLocator();
+$locator->registerSubscriber($subscriber);
+```
+
+## Problem
+
 The main problem with this locator is that you do not have the ability to implement a lazy load of the dependencies for
 this handler. The second problem is the need to explicitly register all handlers, even if you need to handle only one
 query at a run time.

--- a/docs/query/locator/psr-11_container.md
+++ b/docs/query/locator/psr-11_container.md
@@ -15,7 +15,7 @@ $handler = static function (ContactByNameQuery $query) {
     // do something
 };
 
-// example of registr handler in PSR-11 container
+// example of register handler in PSR-11 container
 // container on request $container->get('acme.demo.query.handler.contact.by_name') must return $handler
 //$container = new Container();
 //$container->set('acme.demo.query.handler.contact.by_name', $handler);
@@ -38,8 +38,8 @@ class ContactByNameHandler
     }
 }
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.query.handler.contact.by_name') must return $handler
+// example of register handler in PSR-11 container
+// container on request $container->get('acme.demo.query.handler.contact.by_name') must return handler
 //$container = new Container();
 //$container->set('acme.demo.query.handler.contact.by_name', new ContactByNameHandler());
 
@@ -61,12 +61,42 @@ class ContactByNameHandler
     }
 }
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.query.handler.contact.by_name') must return $handler
+// example of register handler in PSR-11 container
+// container on request $container->get('acme.demo.query.handler.contact.by_name') must return handler
 //$container = new Container();
 //$container->set('acme.demo.query.handler.contact.by_name', new ContactByNameHandler());
 
 // register query handler service in handler locator
 $locator = new ContainerQueryHandlerLocator($container);
 $locator->registerService(ContactByNameQuery::class, 'acme.demo.query.handler.contact.by_name', 'handleContactByName');
+```
+
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ContactQuerySubscriber implements QuerySubscriber
+{
+    public static function getSubscribedQueries(): array
+    {
+        return [
+            ContactByNameQuery::class => 'getByNameQuery',
+        ];
+    }
+
+    public function getByNameQuery(ContactByNameQuery $query)
+    {
+        // return some data
+    }
+}
+
+// example of register subscriber in PSR-11 container
+// container on request $container->get('acme.demo.query.subscriber.contact') must return subscriber
+//$container = new Container();
+//$container->set('acme.demo.query.subscriber.contact', new ContactQuerySubscriber());
+
+// register query handler service in handler locator
+$locator = new ContainerQueryHandlerLocator($container);
+$locator->registerSubscriberService('acme.demo.query.subscriber.contact', ContactQuerySubscriber::class);
 ```

--- a/docs/query/locator/symfony_container.md
+++ b/docs/query/locator/symfony_container.md
@@ -67,7 +67,64 @@ services:
             - [ registerService, [ 'ContactByNameQuery', 'acme.demo.query.handler.contact.by_name', 'handleContactByName' ] ]
 ```
 
-> **Note**
->
-> You can [tagged](https://symfony.com/doc/current/service_container/tags.html) query handler services for optimize
-> register the services in query locator.
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ContactQuerySubscriber implements QuerySubscriber
+{
+    public static function getSubscribedQueries(): array
+    {
+        return [
+            ContactByNameQuery::class => 'getByNameQuery',
+        ];
+    }
+
+    public function getByNameQuery(ContactByNameQuery $query)
+    {
+        // return some data
+    }
+}
+```
+
+YAML configuration for this:
+
+```yml
+services:
+    ContactQuerySubscriber: ~
+
+        class: GpsLab\Component\Query\Handler\Locator\SymfonyContainerQueryHandlerLocator
+        calls:
+            - [ setContainer, [ '@service_container' ] ]
+            - [ registerSubscriberService, [ 'ContactQuerySubscriber', 'ContactQuerySubscriber' ] ]
+```
+
+## Tagging
+
+You can [tagged](https://symfony.com/doc/current/service_container/tags.html) query handler services for optimize
+register the services in query locator. You can autoconfigure your subscribers and automatically register it in
+locator like that:
+
+```php
+// src/Kernel.php
+class Kernel extends BaseKernel
+{
+    protected function build(ContainerBuilder $container): void
+    {
+        $container
+            ->registerForAutoconfiguration(QuerySubscriber::class)
+            ->addTag('gpslab.query.subscriber')
+        ;
+
+        $locator = $container->findDefinition(SymfonyContainerQueryHandlerLocator::class);
+
+        $tagged_subscribers = $container->findTaggedServiceIds('gpslab.query.subscriber');
+
+        foreach ($tagged_subscribers as $id => $attributes) {
+            $subscriber = $container->findDefinition($id);
+            $locator->addMethodCall('registerSubscriberService', [$id, $subscriber->getClass()]);
+        }
+    }
+}
+```

--- a/src/Command/Handler/CommandSubscriber.php
+++ b/src/Command/Handler/CommandSubscriber.php
@@ -16,9 +16,9 @@ interface CommandSubscriber
      * Get called methods for subscribed commands.
      *
      * <code>
-     * [
-     *  [<command_name>, <method_name>],
-     * ]
+     * {
+     *  <command_name>: <method_name>,
+     * }
      * </code>
      *
      * @return array

--- a/src/Command/Handler/CommandSubscriber.php
+++ b/src/Command/Handler/CommandSubscriber.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * GpsLab component.
+ *
+ * @author    Peter Gribanov <info@peter-gribanov.ru>
+ * @copyright Copyright (c) 2011, Peter Gribanov
+ * @license   http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Command\Handler;
+
+interface CommandSubscriber
+{
+    /**
+     * Get called methods for subscribed commands.
+     *
+     * <code>
+     * [
+     *  [<command_name>, [<method,. ..>]],
+     * ]
+     * </code>
+     *
+     * @return array
+     */
+    public static function getSubscribedCommands(): array;
+}

--- a/src/Command/Handler/CommandSubscriber.php
+++ b/src/Command/Handler/CommandSubscriber.php
@@ -17,7 +17,7 @@ interface CommandSubscriber
      *
      * <code>
      * [
-     *  [<command_name>, [<method,. ..>]],
+     *  [<command_name>, <method_name>],
      * ]
      * </code>
      *

--- a/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
@@ -61,8 +61,8 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if ($class_name instanceof CommandSubscriber) {
-            foreach ($class_name::getSubscribedCommands() as $command_name => $method) {
+        if (is_a($class_name, CommandSubscriber::class, true)) {
+            foreach (forward_static_call([$class_name, 'getSubscribedCommands']) as $command_name => $method) {
                 $this->registerService($command_name, $service_name, $method);
             }
         }

--- a/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
@@ -62,10 +62,8 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
         if ($class_name instanceof CommandSubscriber) {
-            foreach ($class_name::getSubscribedCommands() as $command_name => $methods) {
-                foreach ($methods as $method) {
-                    $this->registerService($command_name, $service_name, $method);
-                }
+            foreach ($class_name::getSubscribedCommands() as $command_name => $method) {
+                $this->registerService($command_name, $service_name, $method);
             }
         }
     }

--- a/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace GpsLab\Component\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\CommandSubscriber;
 use Psr\Container\ContainerInterface;
 
 class ContainerCommandHandlerLocator implements CommandHandlerLocator
@@ -52,6 +53,21 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
     public function registerService(string $command_name, string $service, string $method = '__invoke'): void
     {
         $this->command_handler_ids[$command_name] = [$service, $method];
+    }
+
+    /**
+     * @param string $service_name
+     * @param string $class_name
+     */
+    public function registerSubscriberService(string $service_name, string $class_name): void
+    {
+        if ($class_name instanceof CommandSubscriber) {
+            foreach ($class_name::getSubscribedCommands() as $command_name => $methods) {
+                foreach ($methods as $method) {
+                    $this->registerService($command_name, $service_name, $method);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace GpsLab\Component\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\CommandSubscriber;
 
 class DirectBindingCommandHandlerLocator implements CommandHandlerLocator
 {
@@ -29,6 +30,18 @@ class DirectBindingCommandHandlerLocator implements CommandHandlerLocator
     public function registerHandler(string $command_name, callable $handler): void
     {
         $this->handlers[$command_name] = $handler;
+    }
+
+    /**
+     * @param CommandSubscriber $subscriber
+     */
+    public function registerSubscriberService(CommandSubscriber $subscriber): void
+    {
+        foreach ($subscriber::getSubscribedCommands() as $command_name => $methods) {
+            foreach ($methods as $method) {
+                $this->registerHandler($command_name, [$subscriber, $method]);
+            }
+        }
     }
 
     /**

--- a/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
@@ -35,7 +35,7 @@ class DirectBindingCommandHandlerLocator implements CommandHandlerLocator
     /**
      * @param CommandSubscriber $subscriber
      */
-    public function registerSubscriberService(CommandSubscriber $subscriber): void
+    public function registerSubscriber(CommandSubscriber $subscriber): void
     {
         foreach ($subscriber::getSubscribedCommands() as $command_name => $methods) {
             foreach ($methods as $method) {

--- a/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
@@ -37,10 +37,8 @@ class DirectBindingCommandHandlerLocator implements CommandHandlerLocator
      */
     public function registerSubscriber(CommandSubscriber $subscriber): void
     {
-        foreach ($subscriber::getSubscribedCommands() as $command_name => $methods) {
-            foreach ($methods as $method) {
-                $this->registerHandler($command_name, [$subscriber, $method]);
-            }
+        foreach ($subscriber::getSubscribedCommands() as $command_name => $method) {
+            $this->registerHandler($command_name, [$subscriber, $method]);
         }
     }
 

--- a/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
@@ -53,10 +53,8 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
         if ($class_name instanceof CommandSubscriber) {
-            foreach ($class_name::getSubscribedCommands() as $command_name => $methods) {
-                foreach ($methods as $method) {
-                    $this->registerService($command_name, $service_name, $method);
-                }
+            foreach ($class_name::getSubscribedCommands() as $command_name => $method) {
+                $this->registerService($command_name, $service_name, $method);
             }
         }
     }

--- a/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
@@ -52,8 +52,8 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if ($class_name instanceof CommandSubscriber) {
-            foreach ($class_name::getSubscribedCommands() as $command_name => $method) {
+        if (is_a($class_name, CommandSubscriber::class, true)) {
+            foreach (forward_static_call([$class_name, 'getSubscribedCommands']) as $command_name => $method) {
                 $this->registerService($command_name, $service_name, $method);
             }
         }

--- a/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace GpsLab\Component\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\CommandSubscriber;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -43,6 +44,21 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
     public function registerService(string $command_name, string $service, string $method = '__invoke'): void
     {
         $this->command_handler_ids[$command_name] = [$service, $method];
+    }
+
+    /**
+     * @param string $service_name
+     * @param string $class_name
+     */
+    public function registerSubscriberService(string $service_name, string $class_name): void
+    {
+        if ($class_name instanceof CommandSubscriber) {
+            foreach ($class_name::getSubscribedCommands() as $command_name => $methods) {
+                foreach ($methods as $method) {
+                    $this->registerService($command_name, $service_name, $method);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace GpsLab\Component\Query\Handler\Locator;
 
+use GpsLab\Component\Query\Handler\QuerySubscriber;
 use GpsLab\Component\Query\Query;
 use Psr\Container\ContainerInterface;
 
@@ -52,6 +53,21 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
     public function registerService(string $query_name, string $service, string $method = '__invoke'): void
     {
         $this->query_handler_ids[$query_name] = [$service, $method];
+    }
+
+    /**
+     * @param string $service_name
+     * @param string $class_name
+     */
+    public function registerSubscriberService(string $service_name, string $class_name): void
+    {
+        if ($class_name instanceof QuerySubscriber) {
+            foreach ($class_name::getSubscribedQueries() as $query_name => $methods) {
+                foreach ($methods as $method) {
+                    $this->registerService($query_name, $service_name, $method);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
@@ -61,8 +61,8 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if ($class_name instanceof QuerySubscriber) {
-            foreach ($class_name::getSubscribedQueries() as $query_name => $method) {
+        if (is_a($class_name, QuerySubscriber::class, true)) {
+            foreach (forward_static_call([$class_name, 'getSubscribedQueries']) as $query_name => $method) {
                 $this->registerService($query_name, $service_name, $method);
             }
         }

--- a/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
@@ -62,10 +62,8 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
         if ($class_name instanceof QuerySubscriber) {
-            foreach ($class_name::getSubscribedQueries() as $query_name => $methods) {
-                foreach ($methods as $method) {
-                    $this->registerService($query_name, $service_name, $method);
-                }
+            foreach ($class_name::getSubscribedQueries() as $query_name => $method) {
+                $this->registerService($query_name, $service_name, $method);
             }
         }
     }

--- a/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
@@ -37,10 +37,8 @@ class DirectBindingQueryHandlerLocator implements QueryHandlerLocator
      */
     public function registerSubscriber(QuerySubscriber $subscriber): void
     {
-        foreach ($subscriber::getSubscribedQueries() as $query_name => $methods) {
-            foreach ($methods as $method) {
-                $this->registerHandler($query_name, [$subscriber, $method]);
-            }
+        foreach ($subscriber::getSubscribedQueries() as $query_name => $method) {
+            $this->registerHandler($query_name, [$subscriber, $method]);
         }
     }
 

--- a/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace GpsLab\Component\Query\Handler\Locator;
 
+use GpsLab\Component\Query\Handler\QuerySubscriber;
 use GpsLab\Component\Query\Query;
 
 class DirectBindingQueryHandlerLocator implements QueryHandlerLocator
@@ -29,6 +30,18 @@ class DirectBindingQueryHandlerLocator implements QueryHandlerLocator
     public function registerHandler(string $query_name, callable $handler): void
     {
         $this->handlers[$query_name] = $handler;
+    }
+
+    /**
+     * @param QuerySubscriber $subscriber
+     */
+    public function registerSubscriber(QuerySubscriber $subscriber): void
+    {
+        foreach ($subscriber::getSubscribedQueries() as $query_name => $methods) {
+            foreach ($methods as $method) {
+                $this->registerHandler($query_name, [$subscriber, $method]);
+            }
+        }
     }
 
     /**

--- a/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace GpsLab\Component\Query\Handler\Locator;
 
+use GpsLab\Component\Query\Handler\QuerySubscriber;
 use GpsLab\Component\Query\Query;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
@@ -43,6 +44,21 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
     public function registerService(string $query_name, string $service, string $method = '__invoke'): void
     {
         $this->query_handler_ids[$query_name] = [$service, $method];
+    }
+
+    /**
+     * @param string $service_name
+     * @param string $class_name
+     */
+    public function registerSubscriberService(string $service_name, string $class_name): void
+    {
+        if ($class_name instanceof QuerySubscriber) {
+            foreach ($class_name::getSubscribedQueries() as $query_name => $methods) {
+                foreach ($methods as $method) {
+                    $this->registerService($query_name, $service_name, $method);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
@@ -52,8 +52,8 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if ($class_name instanceof QuerySubscriber) {
-            foreach ($class_name::getSubscribedQueries() as $query_name => $method) {
+        if (is_a($class_name, QuerySubscriber::class, true)) {
+            foreach (forward_static_call([$class_name, 'getSubscribedQueries']) as $query_name => $method) {
                 $this->registerService($query_name, $service_name, $method);
             }
         }

--- a/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
@@ -53,10 +53,8 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
         if ($class_name instanceof QuerySubscriber) {
-            foreach ($class_name::getSubscribedQueries() as $query_name => $methods) {
-                foreach ($methods as $method) {
-                    $this->registerService($query_name, $service_name, $method);
-                }
+            foreach ($class_name::getSubscribedQueries() as $query_name => $method) {
+                $this->registerService($query_name, $service_name, $method);
             }
         }
     }

--- a/src/Query/Handler/QuerySubscriber.php
+++ b/src/Query/Handler/QuerySubscriber.php
@@ -16,9 +16,9 @@ interface QuerySubscriber
      * Get called methods for subscribed queries.
      *
      * <code>
-     * [
-     *  [<query_name>, <method_name>],
-     * ]
+     * {
+     *  <query_name>: <method_name>,
+     * }
      * </code>
      *
      * @return array

--- a/src/Query/Handler/QuerySubscriber.php
+++ b/src/Query/Handler/QuerySubscriber.php
@@ -17,7 +17,7 @@ interface QuerySubscriber
      *
      * <code>
      * [
-     *  [<query_name>, [<method,. ..>]],
+     *  [<query_name>, <method_name>],
      * ]
      * </code>
      *

--- a/src/Query/Handler/QuerySubscriber.php
+++ b/src/Query/Handler/QuerySubscriber.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * GpsLab component.
+ *
+ * @author    Peter Gribanov <info@peter-gribanov.ru>
+ * @copyright Copyright (c) 2011, Peter Gribanov
+ * @license   http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Query\Handler;
+
+interface QuerySubscriber
+{
+    /**
+     * Get called methods for subscribed queries.
+     *
+     * <code>
+     * [
+     *  [<query_name>, [<method,. ..>]],
+     * ]
+     * </code>
+     *
+     * @return array
+     */
+    public static function getSubscribedQueries(): array;
+}

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -14,7 +14,9 @@ namespace GpsLab\Component\Tests\Command\Handler\Locator;
 use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Handler\Locator\ContainerCommandHandlerLocator;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
+use GpsLab\Component\Tests\Fixture\Command\Handler\ContestCommandSubscriber;
 use GpsLab\Component\Tests\Fixture\Command\Handler\CreateContactHandler;
+use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -69,6 +71,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($this->command);
+        $this->assertIsCallable($handler);
         $this->assertSame($this->handler, $handler);
     }
 
@@ -93,6 +96,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($command);
+        $this->assertIsCallable($handler);
         $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
@@ -138,5 +142,33 @@ class ContainerCommandHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler($this->command);
         $this->assertNull($handler);
+    }
+
+    public function testRegisterSubscriber(): void
+    {
+        $service = 'foo';
+        $subscriber = new ContestCommandSubscriber();
+
+        $this->container
+            ->expects($this->exactly(3))
+            ->method('get')
+            ->with($service)
+            ->willReturn($subscriber)
+        ;
+
+        $this->locator->registerSubscriberService($service, get_class($subscriber));
+
+        $handler = $this->locator->findHandler(new CreateContact());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onCreate'], $handler);
+
+        // double call ContainerInterface::get()
+        $handler = $this->locator->findHandler(new CreateContact());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onCreate'], $handler);
+
+        $handler = $this->locator->findHandler(new RenameContactCommand());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onRename'], $handler);
     }
 }

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -160,15 +160,15 @@ class ContainerCommandHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         $handler = $this->locator->findHandler(new RenameContactCommand());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onRename'], $handler);
+        $this->assertSame([$subscriber, 'handleRename'], $handler);
     }
 }

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -63,7 +63,6 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
 
     public function testRegisterSubscriber(): void
     {
-        $service = 'foo';
         $subscriber = new ContestCommandSubscriber();
 
         $this->locator->registerSubscriber($subscriber);

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -69,15 +69,15 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         $handler = $this->locator->findHandler(new RenameContactCommand());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onRename'], $handler);
+        $this->assertSame([$subscriber, 'handleRename'], $handler);
     }
 }

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 namespace GpsLab\Component\Tests\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\Handler\ContestCommandSubscriber;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
-use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 namespace GpsLab\Component\Tests\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Tests\Fixture\Command\CreateContact;
+use GpsLab\Component\Tests\Fixture\Command\Handler\ContestCommandSubscriber;
+use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -56,5 +59,26 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler($this->command);
         $this->assertNull($handler);
+    }
+
+    public function testRegisterSubscriber(): void
+    {
+        $service = 'foo';
+        $subscriber = new ContestCommandSubscriber();
+
+        $this->locator->registerSubscriber($subscriber);
+
+        $handler = $this->locator->findHandler(new CreateContact());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onCreate'], $handler);
+
+        // double call ContainerInterface::get()
+        $handler = $this->locator->findHandler(new CreateContact());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onCreate'], $handler);
+
+        $handler = $this->locator->findHandler(new RenameContactCommand());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onRename'], $handler);
     }
 }

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 namespace GpsLab\Component\Tests\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\Handler\ContestCommandSubscriber;
-use GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator;
 use GpsLab\Component\Tests\Fixture\Command\Handler\RenameContactHandler;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -174,15 +174,15 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         $handler = $this->locator->findHandler(new RenameContactCommand());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onRename'], $handler);
+        $this->assertSame([$subscriber, 'handleRename'], $handler);
     }
 }

--- a/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
+++ b/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
@@ -18,55 +18,29 @@ use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 class ContestCommandSubscriber implements CommandSubscriber
 {
     /**
-     * @var CreateContact|null
-     */
-    private $create_contact_command;
-
-    /**
-     * @var RenameContactCommand|null
-     */
-    private $rename_contact_command;
-
-    /**
      * @return array
      */
     public static function getSubscribedCommands(): array
     {
         return [
-            CreateContact::class => 'onCreate',
-            RenameContactCommand::class => 'onRename',
+            CreateContact::class => 'handleCreate',
+            RenameContactCommand::class => 'handleRename',
         ];
     }
 
     /**
      * @param CreateContact $command
      */
-    public function onCreate(CreateContact $command): void
+    public function handleCreate(CreateContact $command): void
     {
-        $this->create_contact_command = $command;
+        // do something
     }
 
     /**
      * @param RenameContactCommand $command
      */
-    public function onRename(RenameContactCommand $command): void
+    public function handleRename(RenameContactCommand $command): void
     {
-        $this->rename_contact_command = $command;
-    }
-
-    /**
-     * @return CreateContact|null
-     */
-    public function getCreateContactCommand(): ?CreateContact
-    {
-        return $this->create_contact_command;
-    }
-
-    /**
-     * @return RenameContactCommand|null
-     */
-    public function getRenameContactCommand(): ?RenameContactCommand
-    {
-        return $this->rename_contact_command;
+        // do something
     }
 }

--- a/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
+++ b/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
@@ -1,6 +1,13 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * GpsLab component.
+ *
+ * @author    Peter Gribanov <info@peter-gribanov.ru>
+ * @copyright Copyright (c) 2011, Peter Gribanov
+ * @license   http://opensource.org/licenses/MIT
+ */
 
 namespace GpsLab\Component\Tests\Fixture\Command\Handler;
 

--- a/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
+++ b/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+
+namespace GpsLab\Component\Tests\Fixture\Command\Handler;
+
+use GpsLab\Component\Command\Handler\CommandSubscriber;
+use GpsLab\Component\Tests\Fixture\Command\CreateContact;
+use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
+
+class ContestCommandSubscriber implements CommandSubscriber
+{
+    /**
+     * @var CreateContact|null
+     */
+    private $create_contact_command;
+
+    /**
+     * @var RenameContactCommand|null
+     */
+    private $rename_contact_command;
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedCommands(): array
+    {
+        return [
+            CreateContact::class => 'onCreate',
+            RenameContactCommand::class => 'onRename',
+        ];
+    }
+
+    /**
+     * @param CreateContact $command
+     */
+    public function onCreate(CreateContact $command): void
+    {
+        $this->create_contact_command = $command;
+    }
+
+    /**
+     * @param RenameContactCommand $command
+     */
+    public function onRename(RenameContactCommand $command): void
+    {
+        $this->rename_contact_command = $command;
+    }
+
+    /**
+     * @return CreateContact|null
+     */
+    public function getCreateContactCommand(): ?CreateContact
+    {
+        return $this->create_contact_command;
+    }
+
+    /**
+     * @return RenameContactCommand|null
+     */
+    public function getRenameContactCommand(): ?RenameContactCommand
+    {
+        return $this->rename_contact_command;
+    }
+}

--- a/tests/Fixture/Query/Handler/ContestQuerySubscriber.php
+++ b/tests/Fixture/Query/Handler/ContestQuerySubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author    Peter Gribanov <info@peter-gribanov.ru>
+ * @copyright Copyright (c) 2011, Peter Gribanov
+ * @license   http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Tests\Fixture\Query\Handler;
+
+use GpsLab\Component\Query\Handler\QuerySubscriber;
+use GpsLab\Component\Tests\Fixture\Query\ContactByIdentity;
+use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
+
+class ContestQuerySubscriber implements QuerySubscriber
+{
+    /**
+     * @return array
+     */
+    public static function getSubscribedQueries(): array
+    {
+        return [
+            ContactByIdentity::class => 'getByIdentity',
+            ContactByNameQuery::class => 'getByNameQuery',
+        ];
+    }
+
+    /**
+     * @param ContactByIdentity $query
+     *
+     * @return string
+     */
+    public function getByIdentity(ContactByIdentity $query): string
+    {
+        return get_class($query);
+    }
+
+    /**
+     * @param ContactByNameQuery $query
+     *
+     * @return string
+     */
+    public function getByNameQuery(ContactByNameQuery $query): string
+    {
+        return get_class($query);
+    }
+}

--- a/tests/Fixture/Query/Handler/ContestQuerySubscriber.php
+++ b/tests/Fixture/Query/Handler/ContestQuerySubscriber.php
@@ -36,6 +36,7 @@ class ContestQuerySubscriber implements QuerySubscriber
      */
     public function getByIdentity(ContactByIdentity $query): string
     {
+        // return some data
         return get_class($query);
     }
 
@@ -46,6 +47,7 @@ class ContestQuerySubscriber implements QuerySubscriber
      */
     public function getByNameQuery(ContactByNameQuery $query): string
     {
+        // return some data
         return get_class($query);
     }
 }

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -17,7 +17,6 @@ use GpsLab\Component\Tests\Fixture\Query\ContactByIdentity;
 use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContactByIdentityHandler;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContestQuerySubscriber;
-use Psr\Container\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -14,7 +14,10 @@ namespace GpsLab\Component\Tests\Query\Handler\Locator;
 use GpsLab\Component\Query\Handler\Locator\ContainerQueryHandlerLocator;
 use GpsLab\Component\Query\Query;
 use GpsLab\Component\Tests\Fixture\Query\ContactByIdentity;
+use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContactByIdentityHandler;
+use GpsLab\Component\Tests\Fixture\Query\Handler\ContestQuerySubscriber;
+use Psr\Container\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -138,5 +141,33 @@ class ContainerQueryHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler($this->query);
         $this->assertNull($handler);
+    }
+
+    public function testRegisterSubscriber(): void
+    {
+        $service = 'foo';
+        $subscriber = new ContestQuerySubscriber();
+
+        $this->container
+            ->expects($this->exactly(3))
+            ->method('get')
+            ->with($service)
+            ->willReturn($subscriber)
+        ;
+
+        $this->locator->registerSubscriberService($service, get_class($subscriber));
+
+        $handler = $this->locator->findHandler(new ContactByIdentity());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByIdentity'], $handler);
+
+        // double call ContainerInterface::get()
+        $handler = $this->locator->findHandler(new ContactByIdentity());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByIdentity'], $handler);
+
+        $handler = $this->locator->findHandler(new ContactByNameQuery());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByNameQuery'], $handler);
     }
 }

--- a/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
@@ -13,6 +13,9 @@ namespace GpsLab\Component\Tests\Query\Handler\Locator;
 
 use GpsLab\Component\Query\Handler\Locator\DirectBindingQueryHandlerLocator;
 use GpsLab\Component\Query\Query;
+use GpsLab\Component\Tests\Fixture\Query\ContactByIdentity;
+use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
+use GpsLab\Component\Tests\Fixture\Query\Handler\ContestQuerySubscriber;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -56,5 +59,25 @@ class DirectBindingQueryHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler($this->query);
         $this->assertNull($handler);
+    }
+
+    public function testRegisterSubscriber(): void
+    {
+        $subscriber = new ContestQuerySubscriber();
+
+        $this->locator->registerSubscriber($subscriber);
+
+        $handler = $this->locator->findHandler(new ContactByIdentity());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByIdentity'], $handler);
+
+        // double call ContainerInterface::get()
+        $handler = $this->locator->findHandler(new ContactByIdentity());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByIdentity'], $handler);
+
+        $handler = $this->locator->findHandler(new ContactByNameQuery());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByNameQuery'], $handler);
     }
 }


### PR DESCRIPTION
Create `CommandSubscriber` for subscribe on several commands. Example usega for PSR-11 container:

```php
class ArticleCommandSubscriber implements CommandSubscriber
{
    public static function getSubscribedCommands(): array
    {
        return [
            RenameArticleCommand::class => 'handleRename',
        ];
    }

    public function handleRename(RenameArticleCommand $command): void
    {
        // do something
    }
}

// example of register subscriber in PSR-11 container
// container on request $container->get('acme.demo.command.handler.article.rename') must return subscriber
//$container = new Container();
//$container->set('acme.demo.command.subscriber.article', new ArticleCommandSubscriber());

// register command handler service in handler locator
$locator = new ContainerCommandHandlerLocator($container);
$locator->registerSubscriberService('acme.demo.command.subscriber.article', ArticleCommandSubscriber::class);
```

Create `QuerySubscriber` for subscribe on several queries. Example usega for PSR-11 container:

```php
class ContactQuerySubscriber implements QuerySubscriber
{
    public static function getSubscribedQueries(): array
    {
        return [
            ContactByNameQuery::class => 'getByNameQuery',
        ];
    }

    public function getByNameQuery(ContactByNameQuery $query)
    {
        // return some data
    }
}

// example of register subscriber in PSR-11 container
// container on request $container->get('acme.demo.query.subscriber.contact') must return subscriber
//$container = new Container();
//$container->set('acme.demo.query.subscriber.contact', new ContactQuerySubscriber());

// register query handler service in handler locator
$locator = new ContainerQueryHandlerLocator($container);
$locator->registerSubscriberService('acme.demo.query.subscriber.contact', ContactQuerySubscriber::class);
```