### PR TITLE
Release 2.0

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 $header = <<<EOF
 GpsLab component.

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,6 +21,12 @@ return PhpCsFixer\Config::create()
         'class_definition' => [
             'multiLineExtendsEachSingleLine' => true,
         ],
+        'no_superfluous_phpdoc_tags' => false,
+        'blank_line_after_opening_tag' => false,
+        'phpdoc_no_empty_return' => false,
+        'ordered_imports' => [
+            'sort_algorithm' => 'alpha',
+        ],
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -32,5 +32,6 @@ return PhpCsFixer\Config::create()
         PhpCsFixer\Finder::create()
             ->in(__DIR__.'/src')
             ->in(__DIR__.'/tests')
+            ->notPath('bootstrap.php')
     )
 ;

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -8,4 +8,3 @@ disabled:
   - phpdoc_align
   - blank_line_after_opening_tag
   - phpdoc_no_empty_return
-  - no_superfluous_phpdoc_tags

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,6 +2,10 @@ preset: symfony
 
 enabled:
   - short_array_syntax
+  - alpha_ordered_imports
 
 disabled:
   - phpdoc_align
+  - blank_line_after_opening_tag
+  - phpdoc_no_empty_return
+  - no_superfluous_phpdoc_tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ install:
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --dev --no-update; fi;
     - if [ "$PREDIS_VERSION" != "" ]; then composer require "predis/predis:${PREDIS_VERSION}" --dev --no-update; fi;
     - composer install --prefer-dist --no-interaction --no-scripts --no-progress
+    # Predis client in version 1.0 is not iterable
+    - if [ "$PREDIS_VERSION" = "1.0.*" ]; then cp .travis/predis_10_phpstan.neon phpstan.neon; fi;
 
 script:
     - vendor/bin/phpunit --verbose --coverage-clover build/coverage-clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,8 @@ install:
     - composer install --prefer-dist --no-interaction --no-scripts --no-progress
 
 script:
-    - if [ "$COVERALLS" != "1" ]; then vendor/bin/phpunit --verbose; fi;
-    - if [ "$COVERALLS" = "1" ]; then vendor/bin/phpunit --verbose --coverage-clover build/coverage-clover.xml; fi;
-    - if [ "$PUBSUB_PREDIS_VERSION" != "" ]; then vendor/bin/phpstan analyse; fi;
+    - vendor/bin/phpunit --verbose --coverage-clover build/coverage-clover.xml
+    - vendor/bin/phpstan analyse
 
 after_script:
     - php ocular.phar code-coverage:upload --format=php-clover build/coverage-clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
 script:
     - if [ "$COVERALLS" != "1" ]; then vendor/bin/phpunit --verbose; fi;
     - if [ "$COVERALLS" = "1" ]; then vendor/bin/phpunit --verbose --coverage-clover build/coverage-clover.xml; fi;
+    - if [ "$PUBSUB_PREDIS_VERSION" != "" ]; then vendor/bin/phpstan analyse; fi;
 
 after_script:
     - if [ "$COVERALLS" = "1" ]; then vendor/bin/ocular code-coverage:upload --format=php-clover build/coverage-clover.xml; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
         - php: 7.1
           dist: trusty
           env: SYMFONY_VERSION=4.4.*
-        - php: 7.1
+        - php: 7.2
           dist: trusty
           env: SYMFONY_VERSION=5.0.*
         - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ matrix:
         - php: 7.1
           dist: trusty
           env: PREDIS_VERSION=1.1.*
-        - php: 7.2
-          env: PUBSUB_PREDIS_VERSION=2.0.*
 
 before_install:
     - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then echo 'xdebug.enable = on' >> /etc/hhvm/php.ini; fi
@@ -43,7 +41,6 @@ before_install:
 install:
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --dev --no-update; fi;
     - if [ "$PREDIS_VERSION" != "" ]; then composer require "predis/predis:${PREDIS_VERSION}" --dev --no-update; fi;
-    - if [ "$PUBSUB_PREDIS_VERSION" != "" ]; then composer require "superbalist/php-pubsub-redis:${PUBSUB_PREDIS_VERSION}" --dev --no-update; fi;
     - composer install --prefer-dist --no-interaction --no-scripts --no-progress
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,13 @@ matrix:
           env: SYMFONY_VERSION=2.8.*
         - php: 7.1
           dist: trusty
-          env: SYMFONY_VERSION=3.0.*
+          env: SYMFONY_VERSION=3.4.*
+        - php: 7.1
+          dist: trusty
+          env: SYMFONY_VERSION=4.4.*
+        - php: 7.1
+          dist: trusty
+          env: SYMFONY_VERSION=5.0.*
         - php: 7.1
           dist: trusty
           env: PREDIS_VERSION=1.0.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,13 @@ matrix:
           dist: trusty
           env: PREDIS_VERSION=1.1.*
         - php: 7.2
-          env: PUBSUB_PREDIS_VERSION=2.0.* COVERALLS=1
+          env: PUBSUB_PREDIS_VERSION=2.0.*
 
 before_install:
     - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then echo 'xdebug.enable = on' >> /etc/hhvm/php.ini; fi
     - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
+    - wget https://scrutinizer-ci.com/ocular.phar
+    - wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.2.0/php-coveralls.phar
 
 install:
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --dev --no-update; fi;
@@ -50,5 +52,5 @@ script:
     - if [ "$PUBSUB_PREDIS_VERSION" != "" ]; then vendor/bin/phpstan analyse; fi;
 
 after_script:
-    - if [ "$COVERALLS" = "1" ]; then vendor/bin/ocular code-coverage:upload --format=php-clover build/coverage-clover.xml; fi;
-    - if [ "$COVERALLS" = "1" ]; then vendor/bin/coveralls -v -c .coveralls.yml; fi;
+    - php ocular.phar code-coverage:upload --format=php-clover build/coverage-clover.xml
+    - php php-coveralls.phar -v -c .coveralls.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,29 +12,26 @@ branches:
 matrix:
     fast_finish: true
     include:
+        - php: 7.4
         - php: 7.3
-        - php: 7.2
         - php: 7.1
-        - php: 7.0
-        - php: 5.6
-        - php: 5.5
           dist: trusty
-        - php: 5.5
+        - php: 7.1
           dist: trusty
           env: SYMFONY_VERSION=2.7.*
-        - php: 5.5
+        - php: 7.1
           dist: trusty
           env: SYMFONY_VERSION=2.8.*
-        - php: 5.5
+        - php: 7.1
           dist: trusty
           env: SYMFONY_VERSION=3.0.*
-        - php: 5.5
+        - php: 7.1
           dist: trusty
           env: PREDIS_VERSION=1.0.*
-        - php: 5.5
+        - php: 7.1
           dist: trusty
           env: PREDIS_VERSION=1.1.*
-        - php: 5.6
+        - php: 7.2
           env: PUBSUB_PREDIS_VERSION=2.0.*
 
 before_install:

--- a/.travis/predis_10_phpstan.neon
+++ b/.travis/predis_10_phpstan.neon
@@ -1,0 +1,6 @@
+includes:
+    - phpstan.neon.dist
+
+parameters:
+    ignoreErrors:
+        - '#Predis\\Client<Predis\\Client>#'

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ composer require gpslab/cqrs
 * [Bus](docs/command/command_bus.md)
 * Handler
   * [Create handler](docs/command/handler.md)
-  * Locator
+  * Locator and Subscribers
     * [Direct binding locator](docs/command/locator/direct_binding.md)
     * [PSR-11 Container locator](docs/command/locator/psr-11_container.md) *([PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md))*
     * [Symfony container locator](docs/command/locator/symfony_container.md) *(Symfony 3.3 [implements](http://symfony.com/blog/new-in-symfony-3-3-psr-11-containers) a [PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md))*
@@ -46,19 +46,175 @@ composer require gpslab/cqrs
 * [Middleware](https://github.com/gpslab/middleware)
 * [Payload](https://github.com/gpslab/payload)
 
+### Simple usage commands
+
+Commands, in the [CQRS](https://martinfowler.com/bliki/CQRS.html) approach, are designed to change the data in the
+application.
+
+For example, consider the procedure for renaming an article.
+
+Create a command to rename:
+
+```php
+use GpsLab\Component\Command\Command;
+
+class RenameArticleCommand implements Command
+{
+    public $article_id;
+
+    public $new_name = '';
+}
+```
+
+> **Note**
+>
+> To simplify the filling of the command, you can use [payload](https://github.com/gpslab/payload).
+
+You can use any implementations of [callable type](http://php.net/manual/en/language.types.callable.php) as a command
+handler. We recommend using public methods of classes as handlers. For example we use [Doctrine ORM](https://github.com/doctrine/doctrine2).
+
+```php
+use GpsLab\Component\Command\Command;
+use Doctrine\ORM\EntityManagerInterface;
+
+class RenameArticleHandler
+{
+    private $em;
+
+    public function __construct(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
+
+    public function handleRenameArticle(RenameArticleCommand $command): void
+    {
+        // get article by id
+        $article = $this->em->getRepository(Article::class)->find($command->article_id);
+        $article->rename($command->new_name);
+    }
+}
+```
+
+And now we register handler and handle command.
+
+```php
+use GpsLab\Component\Command\Bus\HandlerLocatedCommandBus;
+use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
+
+// register command handler in handler locator
+$handler = new RenameArticleHandler($em);
+$locator = new DirectBindingCommandHandlerLocator();
+$locator->registerHandler(RenameArticleCommand::class, [$handler, 'handleRenameArticle']);
+
+// create bus with command handler locator
+$bus = new HandlerLocatedCommandBus($locator);
+
+// ...
+
+// create rename article command
+$command = new RenameArticleCommand();
+$command->article_id = $article_id;
+$command->new_name = $new_name;
+
+// handle command
+$bus->handle($command);
+```
+
+For the asynchronous handle a command you can use `CommandQueue`.
+
+> **Note**
+>
+> To monitor the execution of commands, you can use [middleware](https://github.com/gpslab/middleware).
+
+
 ## Query
 
 * **[Simple usage](docs/query/simple_usage.md)**
 * [Bus](docs/query/query_bus.md)
 * Handler
   * [Create handler](docs/query/handler.md)
-  * Locator
+  * Locator and Subscribers
     * [Direct binding locator](docs/query/locator/direct_binding.md)
     * [PSR-11 Container locator](docs/query/locator/psr-11_container.md) *([PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md))*
     * [Symfony container locator](docs/query/locator/symfony_container.md) *(Symfony 3.3 [implements](http://symfony.com/blog/new-in-symfony-3-3-psr-11-containers) a [PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md))*
 * [Middleware](https://github.com/gpslab/middleware)
 * [Payload](https://github.com/gpslab/payload)
 * [Doctrine specification query](https://github.com/gpslab/specification-query)
+
+### Simple usage queries
+
+Query, in the [CQRS](https://martinfowler.com/bliki/CQRS.html) approach, are designed to get the data in the
+application.
+
+For example, consider the procedure for get an article by identity.
+
+Create a query:
+
+```php
+use GpsLab\Component\Query\Query;
+
+class ArticleByIdentityQuery implements Query
+{
+    public $article_id;
+}
+```
+
+> **Note**
+>
+> To simplify the filling of the query, you can use [payload](https://github.com/gpslab/payload).
+
+You can use any implementations of [callable type](http://php.net/manual/en/language.types.callable.php) as a query
+handler. We recommend using public methods of classes as handlers. For example we use [Doctrine ORM](https://github.com/doctrine/doctrine2).
+
+```php
+use GpsLab\Component\Query\Query;
+use Doctrine\ORM\EntityManagerInterface;
+
+class ArticleByIdentityHandler
+{
+    private $em;
+
+    public function __construct(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
+
+    public function handleArticleByIdentity(ArticleByIdentityQuery $query)
+    {
+        // get article by id
+        return $this->em->getRepository(Article::class)->find($query->article_id);
+    }
+}
+```
+
+And now we register handler and handle query.
+
+```php
+use GpsLab\Component\Query\Bus\HandlerLocatedQueryBus;
+use GpsLab\Component\Query\Handler\Locator\DirectBindingQueryHandlerLocator;
+
+// register query handler in handler locator
+$handler = new ArticleByIdentityHandler($em);
+$locator = new DirectBindingQueryHandlerLocator();
+$locator->registerHandler(ArticleByIdentityQuery::class, [$handler, 'handleArticleByIdentity']);
+
+// create bus with query handler locator
+$bus = new HandlerLocatedQueryBus($locator);
+
+// ...
+
+// create find article query
+$query = new ArticleByIdentityQuery();
+$query->article_id = $article_id;
+
+// handle query
+$article = $bus->handle($query);
+```
+
+> **Note**
+>
+> To monitor the execution of commands, you can use [middleware](https://github.com/gpslab/middleware).
+
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,6 @@
         "phpunit/phpunit": "^7.0|^8.2",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
-        "scrutinizer/ocular": "~1.3",
-        "php-coveralls/php-coveralls": "^1.0",
         "superbalist/php-pubsub-redis": "2.0.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,9 @@
         "predis/predis": "~1.0|~1.1",
         "phpunit/phpunit": "^7.0|^8.2",
         "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan-phpunit": "^0.12",
         "scrutinizer/ocular": "~1.3",
-        "php-coveralls/php-coveralls": "^1.0"
+        "php-coveralls/php-coveralls": "^1.0",
+        "superbalist/php-pubsub-redis": "2.0.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": ">=5.5.0"
+        "php": ">=7.1.0"
     },
     "require-dev": {
         "psr/container": "~1.0",
@@ -31,7 +31,7 @@
         "symfony/dependency-injection": "~2.3|~3.0",
         "symfony/serializer": "~2.3|~3.0",
         "predis/predis": "~1.0|~1.1",
-        "phpunit/phpunit": "^4.8.36",
+        "phpunit/phpunit": "^7.0|^8.2",
         "scrutinizer/ocular": "~1.3",
         "php-coveralls/php-coveralls": "^1.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,11 @@
     "require-dev": {
         "psr/container": "~1.0",
         "psr/log": "~1.0",
-        "symfony/dependency-injection": "~2.3|~3.0",
-        "symfony/serializer": "~2.3|~3.0",
+        "symfony/dependency-injection": "~2.3|~3.0|~4.0|~5.0",
+        "symfony/serializer": "~2.3|~3.0|~4.0|~5.0",
         "predis/predis": "~1.0|~1.1",
         "phpunit/phpunit": "^7.0|^8.2",
+        "phpstan/phpstan": "^0.12",
         "scrutinizer/ocular": "~1.3",
         "php-coveralls/php-coveralls": "^1.0"
     }

--- a/docs/command/handler.md
+++ b/docs/command/handler.md
@@ -7,7 +7,7 @@ handler.
 The command handler can be a [anonymous function](http://php.net/manual/en/functions.anonymous.php):
 
 ```php
-$handler = function (RenameArticleCommand $command) {
+$handler = static function (RenameArticleCommand $command): void {
     // do something
 };
 
@@ -19,7 +19,7 @@ $locator->registerHandler(RenameArticleCommand::class, $handler);
 It can be a some function:
 
 ```php
-function RenameArticleHandler(RenameArticleCommand $command)
+function RenameArticleHandler(RenameArticleCommand $command): void
 {
     // do something
 }
@@ -34,7 +34,7 @@ It can be a [called object](http://php.net/manual/en/language.oop5.magic.php#obj
 ```php
 class RenameArticleHandler
 {
-    public function __invoke(RenameArticleCommand $command)
+    public function __invoke(RenameArticleCommand $command): void
     {
         // do something
     }
@@ -50,7 +50,7 @@ It can be a static method of class:
 ```php
 class RenameArticleHandler
 {
-    public static function handleRenameArticle(RenameArticleCommand $command)
+    public static function handleRenameArticle(RenameArticleCommand $command): void
     {
         // do something
     }
@@ -66,7 +66,7 @@ It can be a public method of class:
 ```php
 class RenameArticleHandler
 {
-    public function handleRenameArticle(RenameArticleCommand $command)
+    public function handleRenameArticle(RenameArticleCommand $command): void
     {
         // do something
     }
@@ -82,12 +82,12 @@ You can handle many commands in one handler.
 ```php
 class ArticleHandler
 {
-    public function handleRenameArticle(RenameArticleCommand $command)
+    public function handleRenameArticle(RenameArticleCommand $command): void
     {
         // do something
     }
 
-    public function handlePublishArticle(PublishArticleCommand $command)
+    public function handlePublishArticle(PublishArticleCommand $command): void
     {
         // do something
     }

--- a/docs/command/locator/direct_binding.md
+++ b/docs/command/locator/direct_binding.md
@@ -29,7 +29,7 @@ class ArticleCommandSubscriber implements CommandSubscriber
     public static function getSubscribedCommands(): array
     {
         return [
-            RenameArticleCommand::class => 'handleRename'
+            RenameArticleCommand::class => 'handleRename',
         ];
     }
 

--- a/docs/command/locator/direct_binding.md
+++ b/docs/command/locator/direct_binding.md
@@ -8,7 +8,7 @@ Direct binding locator is the simplest locator. You bind a specific handler to a
 Example of binding:
 
 ```php
-$handler = function (RenameArticleCommand $command) {
+$handler = static function (RenameArticleCommand $command): void {
     // do something
 };
 

--- a/docs/command/locator/direct_binding.md
+++ b/docs/command/locator/direct_binding.md
@@ -19,6 +19,34 @@ $locator->registerHandler(RenameArticleCommand::class, $handler);
 
 More examples of binding in the section [Create handler](../handler.md).
 
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ArticleCommandSubscriber implements CommandSubscriber
+{
+    public static function getSubscribedCommands(): array
+    {
+        return [
+            RenameArticleCommand::class => 'handleRename'
+        ];
+    }
+
+    public function handleRename(RenameArticleCommand $command): void
+    {
+        // do something
+    }
+}
+
+// register command subscriber in handler locator
+$subscriber = new ArticleCommandSubscriber();
+$locator = new DirectBindingCommandHandlerLocator();
+$locator->registerSubscriber($subscriber);
+```
+
+## Problem
+
 The main problem with this locator is that you do not have the ability to implement a lazy load of the dependencies for
 this handler. The second problem is the need to explicitly register all handlers, even if you need to handle only one
 command at a run time.

--- a/docs/command/locator/psr-11_container.md
+++ b/docs/command/locator/psr-11_container.md
@@ -11,7 +11,7 @@ It's a implementation of locator `CommandHandlerLocator` for
 Example register the [anonymous function](http://php.net/manual/en/functions.anonymous.php) as a command handler:
 
 ```php
-$handler = function (RenameArticleCommand $command) {
+$handler = static function (RenameArticleCommand $command): void {
     // do something
 };
 
@@ -32,7 +32,7 @@ Example register the [called object](http://php.net/manual/en/language.oop5.magi
 ```php
 class RenameArticleHandler
 {
-    public function __invoke(RenameArticleCommand $command)
+    public function __invoke(RenameArticleCommand $command): void
     {
         // do something
     }
@@ -55,7 +55,7 @@ Example register the public method of class as a command handler:
 ```php
 class RenameArticleHandler
 {
-    public function handleRenameArticle(RenameArticleCommand $command)
+    public function handleRenameArticle(RenameArticleCommand $command): void
     {
         // do something
     }

--- a/docs/command/locator/psr-11_container.md
+++ b/docs/command/locator/psr-11_container.md
@@ -15,8 +15,8 @@ $handler = static function (RenameArticleCommand $command): void {
     // do something
 };
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.command.handler.article.rename') must return $handler
+// example of register handler in PSR-11 container
+// container on request $container->get('acme.demo.command.handler.article.rename') must return handler
 //$container = new Container();
 //$container->set('acme.demo.command.handler.article.rename', $handler);
 
@@ -38,8 +38,8 @@ class RenameArticleHandler
     }
 }
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.command.handler.article.rename') must return $handler
+// example of register handler in PSR-11 container
+// container on request $container->get('acme.demo.command.handler.article.rename') must return handler
 //$container = new Container();
 //$container->set('acme.demo.command.handler.article.rename', new RenameArticleHandler());
 
@@ -61,8 +61,8 @@ class RenameArticleHandler
     }
 }
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.command.handler.article.rename') must return $handler
+// example of register handler in PSR-11 container
+// container on request $container->get('acme.demo.command.handler.article.rename') must return handler
 //$container = new Container();
 //$container->set('acme.demo.command.handler.article.rename', new RenameArticleHandler());
 
@@ -81,7 +81,7 @@ class ArticleCommandSubscriber implements CommandSubscriber
     public static function getSubscribedCommands(): array
     {
         return [
-            RenameArticleCommand::class => 'handleRename'
+            RenameArticleCommand::class => 'handleRename',
         ];
     }
 
@@ -91,8 +91,8 @@ class ArticleCommandSubscriber implements CommandSubscriber
     }
 }
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.command.handler.article.rename') must return $handler
+// example of register subscriber in PSR-11 container
+// container on request $container->get('acme.demo.command.handler.article.rename') must return subscriber
 //$container = new Container();
 //$container->set('acme.demo.command.subscriber.article', new ArticleCommandSubscriber());
 

--- a/docs/command/locator/psr-11_container.md
+++ b/docs/command/locator/psr-11_container.md
@@ -70,3 +70,33 @@ class RenameArticleHandler
 $locator = new ContainerCommandHandlerLocator($container);
 $locator->registerService(RenameArticleCommand::class, 'acme.demo.command.handler.article.rename', 'handleRenameArticle');
 ```
+
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ArticleCommandSubscriber implements CommandSubscriber
+{
+    public static function getSubscribedCommands(): array
+    {
+        return [
+            RenameArticleCommand::class => 'handleRename'
+        ];
+    }
+
+    public function handleRename(RenameArticleCommand $command): void
+    {
+        // do something
+    }
+}
+
+// example of registr handler in PSR-11 container
+// container on request $container->get('acme.demo.command.handler.article.rename') must return $handler
+//$container = new Container();
+//$container->set('acme.demo.command.subscriber.article', new ArticleCommandSubscriber());
+
+// register command handler service in handler locator
+$locator = new ContainerCommandHandlerLocator($container);
+$locator->registerSubscriberService('acme.demo.command.subscriber.article', ArticleCommandSubscriber::class);
+```

--- a/docs/command/locator/symfony_container.md
+++ b/docs/command/locator/symfony_container.md
@@ -19,7 +19,7 @@ Example register the [called object](http://php.net/manual/en/language.oop5.magi
 ```php
 class RenameArticleHandler
 {
-    public function __invoke(RenameArticleCommand $command)
+    public function __invoke(RenameArticleCommand $command): void
     {
         // do something
     }
@@ -30,14 +30,12 @@ YAML configuration for this:
 
 ```yml
 services:
-    acme.demo.command.handler.article.rename:
-        class: RenameArticleHandler
+    RenameArticleHandler: ~
 
-    acme.demo.command.locator:
-        class: GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator
+    GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator:
         calls:
             - [ setContainer, [ '@service_container' ] ]
-            - [ registerService, [ 'RenameArticleCommand', 'acme.demo.command.handler.article.rename' ] ]
+            - [ registerService, [ 'RenameArticleCommand', 'RenameArticleHandler' ] ]
 ```
 
 ## Method of class
@@ -47,7 +45,7 @@ Example register the public method of class as a command handler:
 ```php
 class RenameArticleHandler
 {
-    public function handleRenameArticle(RenameArticleCommand $command)
+    public function handleRenameArticle(RenameArticleCommand $command): void
     {
         // do something
     }
@@ -58,14 +56,12 @@ YAML configuration for this:
 
 ```yml
 services:
-    acme.demo.command.handler.article.rename:
-        class: RenameArticleHandler
+    RenameArticleHandler: ~
 
-    acme.demo.command.locator:
-        class: GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator
+    GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator:
         calls:
             - [ setContainer, [ '@service_container' ] ]
-            - [ registerService, [ 'RenameArticleCommand', 'acme.demo.command.handler.article.rename', 'handleRenameArticle' ] ]
+            - [ registerService, [ 'RenameArticleCommand', 'RenameArticleHandler', 'handleRenameArticle' ] ]
 ```
 
 > **Note**

--- a/docs/command/locator/symfony_container.md
+++ b/docs/command/locator/symfony_container.md
@@ -64,7 +64,64 @@ services:
             - [ registerService, [ 'RenameArticleCommand', 'RenameArticleHandler', 'handleRenameArticle' ] ]
 ```
 
-> **Note**
->
-> You can [tagged](https://symfony.com/doc/current/service_container/tags.html) command handler services for optimize
-> register the services in command locator.
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ArticleCommandSubscriber implements CommandSubscriber
+{
+    public static function getSubscribedCommands(): array
+    {
+        return [
+            RenameArticleCommand::class => 'handleRename'
+        ];
+    }
+
+    public function handleRename(RenameArticleCommand $command): void
+    {
+        // do something
+    }
+}
+```
+
+YAML configuration for this:
+
+```yml
+services:
+    ArticleCommandSubscriber: ~
+
+    GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator:
+        calls:
+            - [ setContainer, [ '@service_container' ] ]
+            - [ registerSubscriberService, [ 'ArticleCommandSubscriber', 'ArticleCommandSubscriber' ] ]
+```
+
+## Tagging
+
+You can [tagged](https://symfony.com/doc/current/service_container/tags.html) command handler services for optimize
+register the services in command locator. You can autoconfigure your subscribers and automatically register it in
+locator like that:
+
+```php
+// src/Kernel.php
+class Kernel extends BaseKernel
+{
+    protected function build(ContainerBuilder $container): void
+    {
+        $container
+            ->registerForAutoconfiguration(CommandSubscriber::class)
+            ->addTag('gpslab.command.subscriber')
+        ;
+
+        $locator = $container->findDefinition(SymfonyContainerCommandHandlerLocator::class);
+
+        $tagged_subscribers = $container->findTaggedServiceIds('gpslab.command.subscriber');
+
+        foreach ($tagged_subscribers as $id => $attributes) {
+            $subscriber = $container->findDefinition($id);
+            $locator->addMethodCall('registerSubscriberService', [$id, $subscriber->getClass()]);
+        }
+    }
+}
+```

--- a/docs/command/locator/symfony_container.md
+++ b/docs/command/locator/symfony_container.md
@@ -74,7 +74,7 @@ class ArticleCommandSubscriber implements CommandSubscriber
     public static function getSubscribedCommands(): array
     {
         return [
-            RenameArticleCommand::class => 'handleRename'
+            RenameArticleCommand::class => 'handleRename',
         ];
     }
 

--- a/docs/command/queue/queue.md
+++ b/docs/command/queue/queue.md
@@ -7,7 +7,7 @@ this you can use the interface of the queue.
 ```php
 interface CommandQueue
 {
-    public function publish(Command $command);
+    public function publish(Command $command): void;
 }
 ```
 

--- a/docs/command/queue/serialize/optimized.md
+++ b/docs/command/queue/serialize/optimized.md
@@ -12,20 +12,20 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class RenameArticleCommandSerializer implements NormalizerInterface, DenormalizerInterface
 {
-    const PATTERN = 'RenameArticle;%d;%d;%s';
-    const REGEXP = '/^
+    private const PATTERN = 'RenameArticle;%d;%d;%s';
+    private const REGEXP = '/^
             RenameArticle;      # command type
             (?<article_id>\d+); # article id
             (?<editor_id>\d+);  # editor of the change
             (?<new_name>.+      # new article name
         $/x';
 
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
-        return $data instanceof RenameArticleCommand && $format == PredisPullCommandQueue::FORMAT;
+        return $data instanceof RenameArticleCommand && $format === PredisPullCommandQueue::FORMAT;
     }
 
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): string
     {
         return sprintf(
             self::PATTERN,
@@ -35,7 +35,7 @@ class RenameArticleCommandSerializer implements NormalizerInterface, Denormalize
         );
     }
 
-    public function denormalize($data, $class, $format = null, array $context = [])
+    public function denormalize($data, $class, $format = null, array $context = []): RenameArticleCommand
     {
         if (!preg_match(self::REGEXP, $data, $match)) {
             throw new UnsupportedException();
@@ -48,7 +48,7 @@ class RenameArticleCommandSerializer implements NormalizerInterface, Denormalize
         );
     }
 
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null): bool
     {
         return
             $format === PredisCommandQueue::FORMAT &&

--- a/docs/command/queue/serialize/payload.md
+++ b/docs/command/queue/serialize/payload.md
@@ -13,12 +13,12 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class RenameArticleCommandSerializer implements NormalizerInterface, DenormalizerInterface
 {
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof RenameArticleCommand;
     }
 
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array
     {
         return [
             'type' => 'RenameArticle',
@@ -26,7 +26,7 @@ class RenameArticleCommandSerializer implements NormalizerInterface, Denormalize
         ];
     }
 
-    public function denormalize($data, $class, $format = null, array $context = [])
+    public function denormalize($data, $class, $format = null, array $context = []): RenameArticleCommand
     {
         if ($data['type'] !== 'RenameArticle' || $class !== RenameArticleCommand::class) {
             throw new UnsupportedException();
@@ -35,7 +35,7 @@ class RenameArticleCommandSerializer implements NormalizerInterface, Denormalize
         return new RenameArticleCommand($data['payload']);
     }
 
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null): bool
     {
         return $type === Command::class && isset($data['type'], $data['payload']) && $data['type'] === 'RenameArticle';
     }

--- a/docs/command/queue/subscribe/executing.md
+++ b/docs/command/queue/subscribe/executing.md
@@ -23,7 +23,7 @@ $queue = new ExecutingSubscribeCommandQueue();
 Subscribe to the queue:
 
 ```php
-$handler = function(RenameArticleCommand $command) use ($bus) {
+$handler = static function(RenameArticleCommand $command) use ($bus): void {
     $bus->handle($command);
 };
 

--- a/docs/command/queue/subscribe/predis.md
+++ b/docs/command/queue/subscribe/predis.md
@@ -51,7 +51,7 @@ use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 $locator = new DirectBindingCommandHandlerLocator();
 $bus = new HandlerLocatedCommandBus($locator);
 
-$handler = function(RenameArticleCommand $command) use ($bus) {
+$handler = static function(RenameArticleCommand $command) use ($bus): void {
     $bus->handle($command);
 };
 

--- a/docs/command/simple_usage.md
+++ b/docs/command/simple_usage.md
@@ -34,20 +34,20 @@ class RenameArticleCommand implements Command
 {
     private $article_id;
 
-    private $new_name = '';
+    private $new_name;
 
-    public function __construct(integer $article_id, string $new_name)
+    public function __construct(int $article_id, string $new_name)
     {
         $this->article_id = $article_id;
         $this->new_name = $new_name;
     }
 
-    public function articleId()
+    public function articleId(): int
     {
         return $this->article_id;
     }
 
-    public function newName()
+    public function newName(): string
     {
         return $this->new_name;
     }
@@ -74,7 +74,7 @@ class RenameArticleHandler
         $this->em = $em;
     }
 
-    public function handleRenameArticle(RenameArticleCommand $command)
+    public function handleRenameArticle(RenameArticleCommand $command): void
     {
         // get article by id
         $article = $this->em->getRepository(Article::class)->find($command->article_id);

--- a/docs/command/simple_usage.md
+++ b/docs/command/simple_usage.md
@@ -13,14 +13,8 @@ use GpsLab\Component\Command\Command;
 
 class RenameArticleCommand implements Command
 {
-    /**
-     * @var int
-     */
     public $article_id;
 
-    /**
-     * @var string
-     */
     public $new_name = '';
 }
 ```
@@ -56,7 +50,7 @@ class RenameArticleCommand implements Command
 
 > **Note**
 >
-> To simplify the filling of the team, you can use [payload](https://github.com/gpslab/payload).
+> To simplify the filling of the command, you can use [payload](https://github.com/gpslab/payload).
 
 You can use any implementations of [callable type](http://php.net/manual/en/language.types.callable.php) as a command
 handler. We recommend using public methods of classes as handlers. For example we use [Doctrine ORM](https://github.com/doctrine/doctrine2).
@@ -90,8 +84,9 @@ use GpsLab\Component\Command\Bus\HandlerLocatedCommandBus;
 use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 
 // register command handler in handler locator
+$handler = new RenameArticleHandler($em);
 $locator = new DirectBindingCommandHandlerLocator();
-$locator->registerHandler(RenameArticleCommand::class, [new RenameArticleHandler($em), 'handleRenameArticle']);
+$locator->registerHandler(RenameArticleCommand::class, [$handler, 'handleRenameArticle']);
 
 // create bus with command handler locator
 $bus = new HandlerLocatedCommandBus($locator);

--- a/docs/query/handler.md
+++ b/docs/query/handler.md
@@ -7,7 +7,7 @@ handler.
 The query handler can be a [anonymous function](http://php.net/manual/en/functions.anonymous.php):
 
 ```php
-$handler = function (ContactByIdentityQuery $query) {
+$handler = static function (ContactByIdentityQuery $query) {
     // do something
 };
 

--- a/docs/query/locator/direct_binding.md
+++ b/docs/query/locator/direct_binding.md
@@ -8,7 +8,7 @@ Direct binding locator is the simplest locator. You bind a specific handler to a
 Example of binding:
 
 ```php
-$handler = function (ContactByNameQuery $query) {
+$handler = static function (ContactByNameQuery $query) {
     // do something
 };
 

--- a/docs/query/locator/direct_binding.md
+++ b/docs/query/locator/direct_binding.md
@@ -19,6 +19,34 @@ $locator->registerHandler(ContactByNameQuery::class, $handler);
 
 More examples of binding in the section [Create handler](../handler.md).
 
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ContactQuerySubscriber implements QuerySubscriber
+{
+    public static function getSubscribedQueries(): array
+    {
+        return [
+            ContactByNameQuery::class => 'getByNameQuery',
+        ];
+    }
+
+    public function getByNameQuery(ContactByNameQuery $query)
+    {
+        // return some data
+    }
+}
+
+// register command subscriber in handler locator
+$subscriber = new ContactQuerySubscriber();
+$locator = new DirectBindingQueryHandlerLocator();
+$locator->registerSubscriber($subscriber);
+```
+
+## Problem
+
 The main problem with this locator is that you do not have the ability to implement a lazy load of the dependencies for
 this handler. The second problem is the need to explicitly register all handlers, even if you need to handle only one
 query at a run time.

--- a/docs/query/locator/psr-11_container.md
+++ b/docs/query/locator/psr-11_container.md
@@ -11,7 +11,7 @@ It's a implementation of locator `QueryHandlerLocator` for
 Example register the [anonymous function](http://php.net/manual/en/functions.anonymous.php) as a query handler:
 
 ```php
-$handler = function (ContactByNameQuery $query) {
+$handler = static function (ContactByNameQuery $query) {
     // do something
 };
 

--- a/docs/query/locator/psr-11_container.md
+++ b/docs/query/locator/psr-11_container.md
@@ -15,7 +15,7 @@ $handler = static function (ContactByNameQuery $query) {
     // do something
 };
 
-// example of registr handler in PSR-11 container
+// example of register handler in PSR-11 container
 // container on request $container->get('acme.demo.query.handler.contact.by_name') must return $handler
 //$container = new Container();
 //$container->set('acme.demo.query.handler.contact.by_name', $handler);
@@ -38,8 +38,8 @@ class ContactByNameHandler
     }
 }
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.query.handler.contact.by_name') must return $handler
+// example of register handler in PSR-11 container
+// container on request $container->get('acme.demo.query.handler.contact.by_name') must return handler
 //$container = new Container();
 //$container->set('acme.demo.query.handler.contact.by_name', new ContactByNameHandler());
 
@@ -61,12 +61,42 @@ class ContactByNameHandler
     }
 }
 
-// example of registr handler in PSR-11 container
-// container on request $container->get('acme.demo.query.handler.contact.by_name') must return $handler
+// example of register handler in PSR-11 container
+// container on request $container->get('acme.demo.query.handler.contact.by_name') must return handler
 //$container = new Container();
 //$container->set('acme.demo.query.handler.contact.by_name', new ContactByNameHandler());
 
 // register query handler service in handler locator
 $locator = new ContainerQueryHandlerLocator($container);
 $locator->registerService(ContactByNameQuery::class, 'acme.demo.query.handler.contact.by_name', 'handleContactByName');
+```
+
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ContactQuerySubscriber implements QuerySubscriber
+{
+    public static function getSubscribedQueries(): array
+    {
+        return [
+            ContactByNameQuery::class => 'getByNameQuery',
+        ];
+    }
+
+    public function getByNameQuery(ContactByNameQuery $query)
+    {
+        // return some data
+    }
+}
+
+// example of register subscriber in PSR-11 container
+// container on request $container->get('acme.demo.query.subscriber.contact') must return subscriber
+//$container = new Container();
+//$container->set('acme.demo.query.subscriber.contact', new ContactQuerySubscriber());
+
+// register query handler service in handler locator
+$locator = new ContainerQueryHandlerLocator($container);
+$locator->registerSubscriberService('acme.demo.query.subscriber.contact', ContactQuerySubscriber::class);
 ```

--- a/docs/query/locator/symfony_container.md
+++ b/docs/query/locator/symfony_container.md
@@ -67,7 +67,64 @@ services:
             - [ registerService, [ 'ContactByNameQuery', 'acme.demo.query.handler.contact.by_name', 'handleContactByName' ] ]
 ```
 
-> **Note**
->
-> You can [tagged](https://symfony.com/doc/current/service_container/tags.html) query handler services for optimize
-> register the services in query locator.
+## Subscriber
+
+Example register a subscriber as a command handler:
+
+```php
+class ContactQuerySubscriber implements QuerySubscriber
+{
+    public static function getSubscribedQueries(): array
+    {
+        return [
+            ContactByNameQuery::class => 'getByNameQuery',
+        ];
+    }
+
+    public function getByNameQuery(ContactByNameQuery $query)
+    {
+        // return some data
+    }
+}
+```
+
+YAML configuration for this:
+
+```yml
+services:
+    ContactQuerySubscriber: ~
+
+        class: GpsLab\Component\Query\Handler\Locator\SymfonyContainerQueryHandlerLocator
+        calls:
+            - [ setContainer, [ '@service_container' ] ]
+            - [ registerSubscriberService, [ 'ContactQuerySubscriber', 'ContactQuerySubscriber' ] ]
+```
+
+## Tagging
+
+You can [tagged](https://symfony.com/doc/current/service_container/tags.html) query handler services for optimize
+register the services in query locator. You can autoconfigure your subscribers and automatically register it in
+locator like that:
+
+```php
+// src/Kernel.php
+class Kernel extends BaseKernel
+{
+    protected function build(ContainerBuilder $container): void
+    {
+        $container
+            ->registerForAutoconfiguration(QuerySubscriber::class)
+            ->addTag('gpslab.query.subscriber')
+        ;
+
+        $locator = $container->findDefinition(SymfonyContainerQueryHandlerLocator::class);
+
+        $tagged_subscribers = $container->findTaggedServiceIds('gpslab.query.subscriber');
+
+        foreach ($tagged_subscribers as $id => $attributes) {
+            $subscriber = $container->findDefinition($id);
+            $locator->addMethodCall('registerSubscriberService', [$id, $subscriber->getClass()]);
+        }
+    }
+}
+```

--- a/docs/query/simple_usage.md
+++ b/docs/query/simple_usage.md
@@ -13,9 +13,6 @@ use GpsLab\Component\Query\Query;
 
 class ArticleByIdentityQuery implements Query
 {
-    /**
-     * @var int
-     */
     public $article_id;
 }
 ```
@@ -43,7 +40,7 @@ class ArticleByIdentityQuery implements Query
 
 > **Note**
 >
-> To simplify the filling of the team, you can use [payload](https://github.com/gpslab/payload).
+> To simplify the filling of the query, you can use [payload](https://github.com/gpslab/payload).
 
 You can use any implementations of [callable type](http://php.net/manual/en/language.types.callable.php) as a query
 handler. We recommend using public methods of classes as handlers. For example we use [Doctrine ORM](https://github.com/doctrine/doctrine2).
@@ -76,8 +73,9 @@ use GpsLab\Component\Query\Bus\HandlerLocatedQueryBus;
 use GpsLab\Component\Query\Handler\Locator\DirectBindingQueryHandlerLocator;
 
 // register query handler in handler locator
+$handler = new ArticleByIdentityHandler($em);
 $locator = new DirectBindingQueryHandlerLocator();
-$locator->registerHandler(ArticleByIdentityQuery::class, [new ArticleByIdentityHandler($em), 'handleArticleByIdentity']);
+$locator->registerHandler(ArticleByIdentityQuery::class, [$handler, 'handleArticleByIdentity']);
 
 // create bus with query handler locator
 $bus = new HandlerLocatedQueryBus($locator);

--- a/docs/query/simple_usage.md
+++ b/docs/query/simple_usage.md
@@ -29,12 +29,12 @@ class ArticleByIdentityQuery implements Query
 {
     private $article_id;
 
-    public function __construct(integer $article_id)
+    public function __construct(int $article_id)
     {
         $this->article_id = $article_id;
     }
 
-    public function articleId()
+    public function articleId(): int
     {
         return $this->article_id;
     }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,5 @@
+parameters:
+    level: 0
+    paths:
+        - src
+        - tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,9 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/rules.neon
+
 parameters:
-    level: 0
+    level: 6
     paths:
         - src
         - tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,7 +3,7 @@ includes:
     - vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-    level: 6
+    level: 7
     paths:
         - src
         - tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,3 +7,6 @@ parameters:
     paths:
         - src
         - tests
+    ignoreErrors:
+        # Predis client in version 1.0 is not iterable
+        - '#Predis\\Client<Predis\\Client>#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,6 +7,3 @@ parameters:
     paths:
         - src
         - tests
-    ignoreErrors:
-        # Predis client in version 1.0 is not iterable
-        - '#Predis\\Client<Predis\\Client>#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     bootstrap="tests/bootstrap.php"
 >
     <testsuites>

--- a/src/Command/Bus/CommandBus.php
+++ b/src/Command/Bus/CommandBus.php
@@ -17,5 +17,5 @@ interface CommandBus
     /**
      * @param Command $command
      */
-    public function handle(Command $command);
+    public function handle(Command $command): void;
 }

--- a/src/Command/Bus/CommandBus.php
+++ b/src/Command/Bus/CommandBus.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Bus/HandlerLocatedCommandBus.php
+++ b/src/Command/Bus/HandlerLocatedCommandBus.php
@@ -32,7 +32,7 @@ class HandlerLocatedCommandBus implements CommandBus
     /**
      * @param Command $command
      */
-    public function handle(Command $command)
+    public function handle(Command $command): void
     {
         $handler = $this->locator->findHandler($command);
 
@@ -40,6 +40,6 @@ class HandlerLocatedCommandBus implements CommandBus
             throw HandlerNotFoundException::notFound($command);
         }
 
-        call_user_func($handler, $command);
+        $handler($command);
     }
 }

--- a/src/Command/Bus/HandlerLocatedCommandBus.php
+++ b/src/Command/Bus/HandlerLocatedCommandBus.php
@@ -11,8 +11,8 @@
 namespace GpsLab\Component\Command\Bus;
 
 use GpsLab\Component\Command\Command;
-use GpsLab\Component\Command\Handler\Locator\CommandHandlerLocator;
 use GpsLab\Component\Command\Exception\HandlerNotFoundException;
+use GpsLab\Component\Command\Handler\Locator\CommandHandlerLocator;
 
 class HandlerLocatedCommandBus implements CommandBus
 {

--- a/src/Command/Bus/HandlerLocatedCommandBus.php
+++ b/src/Command/Bus/HandlerLocatedCommandBus.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Exception/HandlerNotFoundException.php
+++ b/src/Command/Exception/HandlerNotFoundException.php
@@ -12,14 +12,14 @@ namespace GpsLab\Component\Command\Exception;
 
 use GpsLab\Component\Command\Command;
 
-class HandlerNotFoundException extends \RuntimeException
+final class HandlerNotFoundException extends \RuntimeException
 {
     /**
      * @param Command $command
      *
      * @return self
      */
-    public static function notFound(Command $command)
+    public static function notFound(Command $command): self
     {
         $parts = explode('\\', get_class($command));
 

--- a/src/Command/Exception/HandlerNotFoundException.php
+++ b/src/Command/Exception/HandlerNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Handler/CommandSubscriber.php
+++ b/src/Command/Handler/CommandSubscriber.php
@@ -21,7 +21,7 @@ interface CommandSubscriber
      * }
      * </code>
      *
-     * @return array
+     * @return array<class-string, string>
      */
     public static function getSubscribedCommands(): array;
 }

--- a/src/Command/Handler/CommandSubscriber.php
+++ b/src/Command/Handler/CommandSubscriber.php
@@ -16,9 +16,9 @@ interface CommandSubscriber
      * Get called methods for subscribed commands.
      *
      * <code>
-     * [
-     *  [<command_name>, <method_name>],
-     * ]
+     * {
+     *  <command_name>: <method_name>,
+     * }
      * </code>
      *
      * @return array

--- a/src/Command/Handler/CommandSubscriber.php
+++ b/src/Command/Handler/CommandSubscriber.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * GpsLab component.
+ *
+ * @author    Peter Gribanov <info@peter-gribanov.ru>
+ * @copyright Copyright (c) 2011, Peter Gribanov
+ * @license   http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Command\Handler;
+
+interface CommandSubscriber
+{
+    /**
+     * Get called methods for subscribed commands.
+     *
+     * <code>
+     * [
+     *  [<command_name>, [<method,. ..>]],
+     * ]
+     * </code>
+     *
+     * @return array
+     */
+    public static function getSubscribedCommands(): array;
+}

--- a/src/Command/Handler/CommandSubscriber.php
+++ b/src/Command/Handler/CommandSubscriber.php
@@ -17,7 +17,7 @@ interface CommandSubscriber
      *
      * <code>
      * [
-     *  [<command_name>, [<method,. ..>]],
+     *  [<command_name>, <method_name>],
      * ]
      * </code>
      *

--- a/src/Command/Handler/Locator/CommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/CommandHandlerLocator.php
@@ -19,5 +19,5 @@ interface CommandHandlerLocator
      *
      * @return callable|null
      */
-    public function findHandler(Command $command);
+    public function findHandler(Command $command): ?callable;
 }

--- a/src/Command/Handler/Locator/CommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/CommandHandlerLocator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
@@ -23,7 +23,7 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
     private $container;
 
     /**
-     * @var array
+     * @var array[]
      */
     private $command_handler_ids = [];
 

--- a/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
@@ -61,8 +61,8 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if ($class_name instanceof CommandSubscriber) {
-            foreach ($class_name::getSubscribedCommands() as $command_name => $method) {
+        if (is_a($class_name, CommandSubscriber::class, true)) {
+            foreach (forward_static_call([$class_name, 'getSubscribedCommands']) as $command_name => $method) {
                 $this->registerService($command_name, $service_name, $method);
             }
         }

--- a/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
@@ -61,8 +61,9 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if (is_a($class_name, CommandSubscriber::class, true)) {
-            foreach (forward_static_call([$class_name, 'getSubscribedCommands']) as $command_name => $method) {
+        $get_subscribed_commands = [$class_name, 'getSubscribedCommands'];
+        if (is_callable($get_subscribed_commands) && is_a($class_name, CommandSubscriber::class, true)) {
+            foreach ($get_subscribed_commands() as $command_name => $method) {
                 $this->registerService($command_name, $service_name, $method);
             }
         }

--- a/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
@@ -96,8 +96,10 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
             return $service;
         }
 
-        if (is_callable([$service, $method])) {
-            return [$service, $method];
+        $handler = [$service, $method];
+
+        if (is_callable($handler)) {
+            return $handler;
         }
 
         return null;

--- a/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
@@ -62,10 +62,8 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
         if ($class_name instanceof CommandSubscriber) {
-            foreach ($class_name::getSubscribedCommands() as $command_name => $methods) {
-                foreach ($methods as $method) {
-                    $this->registerService($command_name, $service_name, $method);
-                }
+            foreach ($class_name::getSubscribedCommands() as $command_name => $method) {
+                $this->registerService($command_name, $service_name, $method);
             }
         }
     }

--- a/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
@@ -38,7 +38,7 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
      *
      * @return callable|null
      */
-    public function findHandler(Command $command)
+    public function findHandler(Command $command): ?callable
     {
         return $this->lazyLoad(get_class($command));
     }
@@ -48,7 +48,7 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
      * @param string $service
      * @param string $method
      */
-    public function registerService($command_name, $service, $method = '__invoke')
+    public function registerService(string $command_name, string $service, string $method = '__invoke'): void
     {
         $this->command_handler_ids[$command_name] = [$service, $method];
     }
@@ -58,10 +58,10 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
      *
      * @return callable|null
      */
-    private function lazyLoad($command_name)
+    private function lazyLoad(string $command_name): ?callable
     {
         if (isset($this->command_handler_ids[$command_name])) {
-            list($service, $method) = $this->command_handler_ids[$command_name];
+            [$service, $method] = $this->command_handler_ids[$command_name];
 
             return $this->resolve($this->container->get($service), $method);
         }
@@ -75,7 +75,7 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
      *
      * @return callable|null
      */
-    private function resolve($service, $method)
+    private function resolve($service, string $method): ?callable
     {
         if (is_callable($service)) {
             return $service;

--- a/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace GpsLab\Component\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\CommandSubscriber;
 use Psr\Container\ContainerInterface;
 
 class ContainerCommandHandlerLocator implements CommandHandlerLocator
@@ -52,6 +53,21 @@ class ContainerCommandHandlerLocator implements CommandHandlerLocator
     public function registerService(string $command_name, string $service, string $method = '__invoke'): void
     {
         $this->command_handler_ids[$command_name] = [$service, $method];
+    }
+
+    /**
+     * @param string $service_name
+     * @param string $class_name
+     */
+    public function registerSubscriberService(string $service_name, string $class_name): void
+    {
+        if ($class_name instanceof CommandSubscriber) {
+            foreach ($class_name::getSubscribedCommands() as $command_name => $methods) {
+                foreach ($methods as $method) {
+                    $this->registerService($command_name, $service_name, $method);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/ContainerCommandHandlerLocator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace GpsLab\Component\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\CommandSubscriber;
 
 class DirectBindingCommandHandlerLocator implements CommandHandlerLocator
 {
@@ -29,6 +30,18 @@ class DirectBindingCommandHandlerLocator implements CommandHandlerLocator
     public function registerHandler(string $command_name, callable $handler): void
     {
         $this->handlers[$command_name] = $handler;
+    }
+
+    /**
+     * @param CommandSubscriber $subscriber
+     */
+    public function registerSubscriberService(CommandSubscriber $subscriber): void
+    {
+        foreach ($subscriber::getSubscribedCommands() as $command_name => $methods) {
+            foreach ($methods as $method) {
+                $this->registerHandler($command_name, [$subscriber, $method]);
+            }
+        }
     }
 
     /**

--- a/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
@@ -38,7 +38,10 @@ class DirectBindingCommandHandlerLocator implements CommandHandlerLocator
     public function registerSubscriber(CommandSubscriber $subscriber): void
     {
         foreach ($subscriber::getSubscribedCommands() as $command_name => $method) {
-            $this->registerHandler($command_name, [$subscriber, $method]);
+            $handler = [$subscriber, $method];
+            if (is_callable($handler)) {
+                $this->registerHandler($command_name, $handler);
+            }
         }
     }
 

--- a/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
@@ -35,7 +35,7 @@ class DirectBindingCommandHandlerLocator implements CommandHandlerLocator
     /**
      * @param CommandSubscriber $subscriber
      */
-    public function registerSubscriberService(CommandSubscriber $subscriber): void
+    public function registerSubscriber(CommandSubscriber $subscriber): void
     {
         foreach ($subscriber::getSubscribedCommands() as $command_name => $methods) {
             foreach ($methods as $method) {

--- a/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
@@ -25,7 +25,7 @@ class DirectBindingCommandHandlerLocator implements CommandHandlerLocator
      * @param string   $command_name
      * @param callable $handler
      */
-    public function registerHandler($command_name, callable $handler)
+    public function registerHandler(string $command_name, callable $handler): void
     {
         $this->handlers[$command_name] = $handler;
     }
@@ -35,10 +35,8 @@ class DirectBindingCommandHandlerLocator implements CommandHandlerLocator
      *
      * @return callable|null
      */
-    public function findHandler(Command $command)
+    public function findHandler(Command $command): ?callable
     {
-        $command_name = get_class($command);
-
-        return isset($this->handlers[$command_name]) ? $this->handlers[$command_name] : null;
+        return $this->handlers[get_class($command)] ?? null;
     }
 }

--- a/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/DirectBindingCommandHandlerLocator.php
@@ -37,10 +37,8 @@ class DirectBindingCommandHandlerLocator implements CommandHandlerLocator
      */
     public function registerSubscriber(CommandSubscriber $subscriber): void
     {
-        foreach ($subscriber::getSubscribedCommands() as $command_name => $methods) {
-            foreach ($methods as $method) {
-                $this->registerHandler($command_name, [$subscriber, $method]);
-            }
+        foreach ($subscriber::getSubscribedCommands() as $command_name => $method) {
+            $this->registerHandler($command_name, [$subscriber, $method]);
         }
     }
 

--- a/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
@@ -87,8 +87,10 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
             return $service;
         }
 
-        if (is_callable([$service, $method])) {
-            return [$service, $method];
+        $handler = [$service, $method];
+
+        if (is_callable($handler)) {
+            return $handler;
         }
 
         return null;

--- a/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
@@ -53,10 +53,8 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
         if ($class_name instanceof CommandSubscriber) {
-            foreach ($class_name::getSubscribedCommands() as $command_name => $methods) {
-                foreach ($methods as $method) {
-                    $this->registerService($command_name, $service_name, $method);
-                }
+            foreach ($class_name::getSubscribedCommands() as $command_name => $method) {
+                $this->registerService($command_name, $service_name, $method);
             }
         }
     }

--- a/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
@@ -29,7 +29,7 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
      *
      * @return callable|null
      */
-    public function findHandler(Command $command)
+    public function findHandler(Command $command): ?callable
     {
         return $this->lazyLoad(get_class($command));
     }
@@ -39,7 +39,7 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
      * @param string $service
      * @param string $method
      */
-    public function registerService($command_name, $service, $method = '__invoke')
+    public function registerService(string $command_name, string $service, string $method = '__invoke'): void
     {
         $this->command_handler_ids[$command_name] = [$service, $method];
     }
@@ -49,10 +49,10 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
      *
      * @return callable|null
      */
-    private function lazyLoad($command_name)
+    private function lazyLoad(string $command_name): ?callable
     {
         if ($this->container instanceof ContainerInterface && isset($this->command_handler_ids[$command_name])) {
-            list($service, $method) = $this->command_handler_ids[$command_name];
+            [$service, $method] = $this->command_handler_ids[$command_name];
 
             return $this->resolve($this->container->get($service), $method);
         }
@@ -66,7 +66,7 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
      *
      * @return callable|null
      */
-    private function resolve($service, $method)
+    private function resolve($service, string $method): ?callable
     {
         if (is_callable($service)) {
             return $service;

--- a/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
@@ -52,8 +52,8 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if ($class_name instanceof CommandSubscriber) {
-            foreach ($class_name::getSubscribedCommands() as $command_name => $method) {
+        if (is_a($class_name, CommandSubscriber::class, true)) {
+            foreach (forward_static_call([$class_name, 'getSubscribedCommands']) as $command_name => $method) {
                 $this->registerService($command_name, $service_name, $method);
             }
         }

--- a/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace GpsLab\Component\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\CommandSubscriber;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -43,6 +44,21 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
     public function registerService(string $command_name, string $service, string $method = '__invoke'): void
     {
         $this->command_handler_ids[$command_name] = [$service, $method];
+    }
+
+    /**
+     * @param string $service_name
+     * @param string $class_name
+     */
+    public function registerSubscriberService(string $service_name, string $class_name): void
+    {
+        if ($class_name instanceof CommandSubscriber) {
+            foreach ($class_name::getSubscribedCommands() as $command_name => $methods) {
+                foreach ($methods as $method) {
+                    $this->registerService($command_name, $service_name, $method);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
@@ -22,7 +22,7 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
     use ContainerAwareTrait;
 
     /**
-     * @var array
+     * @var array[]
      */
     private $command_handler_ids = [];
 

--- a/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
+++ b/src/Command/Handler/Locator/SymfonyContainerCommandHandlerLocator.php
@@ -52,8 +52,9 @@ class SymfonyContainerCommandHandlerLocator implements CommandHandlerLocator, Co
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if (is_a($class_name, CommandSubscriber::class, true)) {
-            foreach (forward_static_call([$class_name, 'getSubscribedCommands']) as $command_name => $method) {
+        $get_subscribed_commands = [$class_name, 'getSubscribedCommands'];
+        if (is_callable($get_subscribed_commands) && is_a($class_name, CommandSubscriber::class, true)) {
+            foreach ($get_subscribed_commands() as $command_name => $method) {
                 $this->registerService($command_name, $service_name, $method);
             }
         }

--- a/src/Command/Queue/CommandQueue.php
+++ b/src/Command/Queue/CommandQueue.php
@@ -21,5 +21,5 @@ interface CommandQueue
      *
      * @return bool
      */
-    public function publish(Command $command);
+    public function publish(Command $command): bool;
 }

--- a/src/Command/Queue/CommandQueue.php
+++ b/src/Command/Queue/CommandQueue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Queue/Pull/MemoryPullCommandQueue.php
+++ b/src/Command/Queue/Pull/MemoryPullCommandQueue.php
@@ -26,7 +26,7 @@ class MemoryPullCommandQueue implements PullCommandQueue
      *
      * @return bool
      */
-    public function publish(Command $command)
+    public function publish(Command $command): bool
     {
         $this->commands[] = $command;
 
@@ -38,7 +38,7 @@ class MemoryPullCommandQueue implements PullCommandQueue
      *
      * @return Command|null
      */
-    public function pull()
+    public function pull(): ?Command
     {
         return array_shift($this->commands);
     }

--- a/src/Command/Queue/Pull/MemoryPullCommandQueue.php
+++ b/src/Command/Queue/Pull/MemoryPullCommandQueue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Queue/Pull/MemoryUniquePullCommandQueue.php
+++ b/src/Command/Queue/Pull/MemoryUniquePullCommandQueue.php
@@ -26,7 +26,7 @@ class MemoryUniquePullCommandQueue implements PullCommandQueue
      *
      * @return bool
      */
-    public function publish(Command $command)
+    public function publish(Command $command): bool
     {
         $index = array_search($command, $this->commands);
 
@@ -45,7 +45,7 @@ class MemoryUniquePullCommandQueue implements PullCommandQueue
      *
      * @return Command|null
      */
-    public function pull()
+    public function pull(): ?Command
     {
         return array_shift($this->commands);
     }

--- a/src/Command/Queue/Pull/MemoryUniquePullCommandQueue.php
+++ b/src/Command/Queue/Pull/MemoryUniquePullCommandQueue.php
@@ -31,7 +31,7 @@ class MemoryUniquePullCommandQueue implements PullCommandQueue
         $index = array_search($command, $this->commands);
 
         // remove exists command and publish it again
-        if ($index !== false) {
+        if (false !== $index) {
             unset($this->commands[$index]);
         }
 

--- a/src/Command/Queue/Pull/MemoryUniquePullCommandQueue.php
+++ b/src/Command/Queue/Pull/MemoryUniquePullCommandQueue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Queue/Pull/PredisPullCommandQueue.php
+++ b/src/Command/Queue/Pull/PredisPullCommandQueue.php
@@ -35,7 +35,7 @@ class PredisPullCommandQueue implements PullCommandQueue
     /**
      * @var string
      */
-    private $queue_name = '';
+    private $queue_name;
 
     /**
      * @param Client          $client
@@ -43,7 +43,7 @@ class PredisPullCommandQueue implements PullCommandQueue
      * @param LoggerInterface $logger
      * @param string          $queue_name
      */
-    public function __construct(Client $client, Serializer $serializer, LoggerInterface $logger, $queue_name)
+    public function __construct(Client $client, Serializer $serializer, LoggerInterface $logger, string $queue_name)
     {
         $this->client = $client;
         $this->serializer = $serializer;
@@ -58,7 +58,7 @@ class PredisPullCommandQueue implements PullCommandQueue
      *
      * @return bool
      */
-    public function publish(Command $command)
+    public function publish(Command $command): bool
     {
         $value = $this->serializer->serialize($command);
 
@@ -70,7 +70,7 @@ class PredisPullCommandQueue implements PullCommandQueue
      *
      * @return Command|null
      */
-    public function pull()
+    public function pull(): ?Command
     {
         $value = $this->client->lpop($this->queue_name);
 
@@ -79,7 +79,13 @@ class PredisPullCommandQueue implements PullCommandQueue
         }
 
         try {
-            return $this->serializer->deserialize($value);
+            $command = $this->serializer->deserialize($value);
+
+            if ($command instanceof Command) {
+                return $command;
+            }
+
+            throw new \RuntimeException(sprintf('The denormalization command is expected "%s", got "%s" inside.', Command::class, get_class($command)));
         } catch (\Exception $e) {
             // it's a critical error
             // it is necessary to react quickly to it

--- a/src/Command/Queue/Pull/PredisPullCommandQueue.php
+++ b/src/Command/Queue/Pull/PredisPullCommandQueue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Queue/Pull/PredisPullCommandQueue.php
+++ b/src/Command/Queue/Pull/PredisPullCommandQueue.php
@@ -19,7 +19,7 @@ use Psr\Log\LoggerInterface;
 class PredisPullCommandQueue implements PullCommandQueue
 {
     /**
-     * @var Client
+     * @var Client<Client>
      */
     private $client;
 
@@ -39,7 +39,7 @@ class PredisPullCommandQueue implements PullCommandQueue
     private $queue_name;
 
     /**
-     * @param Client          $client
+     * @param Client<Client>  $client
      * @param Serializer      $serializer
      * @param LoggerInterface $logger
      * @param string          $queue_name

--- a/src/Command/Queue/Pull/PredisUniquePullCommandQueue.php
+++ b/src/Command/Queue/Pull/PredisUniquePullCommandQueue.php
@@ -35,7 +35,7 @@ class PredisUniquePullCommandQueue implements PullCommandQueue
     /**
      * @var string
      */
-    private $queue_name = '';
+    private $queue_name;
 
     /**
      * @param Client          $client
@@ -43,7 +43,7 @@ class PredisUniquePullCommandQueue implements PullCommandQueue
      * @param LoggerInterface $logger
      * @param string          $queue_name
      */
-    public function __construct(Client $client, Serializer $serializer, LoggerInterface $logger, $queue_name)
+    public function __construct(Client $client, Serializer $serializer, LoggerInterface $logger, string $queue_name)
     {
         $this->client = $client;
         $this->serializer = $serializer;
@@ -58,7 +58,7 @@ class PredisUniquePullCommandQueue implements PullCommandQueue
      *
      * @return bool
      */
-    public function publish(Command $command)
+    public function publish(Command $command): bool
     {
         $value = $this->serializer->serialize($command);
 
@@ -73,7 +73,7 @@ class PredisUniquePullCommandQueue implements PullCommandQueue
      *
      * @return Command|null
      */
-    public function pull()
+    public function pull(): ?Command
     {
         $value = $this->client->lpop($this->queue_name);
 
@@ -82,7 +82,13 @@ class PredisUniquePullCommandQueue implements PullCommandQueue
         }
 
         try {
-            return $this->serializer->deserialize($value);
+            $command = $this->serializer->deserialize($value);
+
+            if ($command instanceof Command) {
+                return $command;
+            }
+
+            throw new \RuntimeException(sprintf('The denormalization command is expected "%s", got "%s" inside.', Command::class, get_class($command)));
         } catch (\Exception $e) {
             // it's a critical error
             // it is necessary to react quickly to it

--- a/src/Command/Queue/Pull/PredisUniquePullCommandQueue.php
+++ b/src/Command/Queue/Pull/PredisUniquePullCommandQueue.php
@@ -19,7 +19,7 @@ use Psr\Log\LoggerInterface;
 class PredisUniquePullCommandQueue implements PullCommandQueue
 {
     /**
-     * @var Client
+     * @var Client<Client>
      */
     private $client;
 
@@ -39,7 +39,7 @@ class PredisUniquePullCommandQueue implements PullCommandQueue
     private $queue_name;
 
     /**
-     * @param Client          $client
+     * @param Client<Client>  $client
      * @param Serializer      $serializer
      * @param LoggerInterface $logger
      * @param string          $queue_name

--- a/src/Command/Queue/Pull/PredisUniquePullCommandQueue.php
+++ b/src/Command/Queue/Pull/PredisUniquePullCommandQueue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Queue/Pull/PullCommandQueue.php
+++ b/src/Command/Queue/Pull/PullCommandQueue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Queue/Pull/PullCommandQueue.php
+++ b/src/Command/Queue/Pull/PullCommandQueue.php
@@ -20,5 +20,5 @@ interface PullCommandQueue extends CommandQueue
      *
      * @return Command|null
      */
-    public function pull();
+    public function pull(): ?Command;
 }

--- a/src/Command/Queue/Serializer/Serializer.php
+++ b/src/Command/Queue/Serializer/Serializer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Queue/Serializer/Serializer.php
+++ b/src/Command/Queue/Serializer/Serializer.php
@@ -17,12 +17,12 @@ interface Serializer
      *
      * @return string
      */
-    public function serialize($data);
+    public function serialize($data): string;
 
     /**
      * @param string $data
      *
      * @return object
      */
-    public function deserialize($data);
+    public function deserialize(string $data);
 }

--- a/src/Command/Queue/Serializer/SymfonySerializer.php
+++ b/src/Command/Queue/Serializer/SymfonySerializer.php
@@ -15,7 +15,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 class SymfonySerializer implements Serializer
 {
-    const DEFAULT_FORMAT = 'predis';
+    public const DEFAULT_FORMAT = 'predis';
 
     /**
      * @var SerializerInterface
@@ -25,16 +25,16 @@ class SymfonySerializer implements Serializer
     /**
      * @var string
      */
-    private $format = self::DEFAULT_FORMAT;
+    private $format;
 
     /**
      * @param SerializerInterface $serializer
-     * @param string|null         $format
+     * @param string              $format
      */
-    public function __construct(SerializerInterface $serializer, $format = null)
+    public function __construct(SerializerInterface $serializer, string $format = self::DEFAULT_FORMAT)
     {
         $this->serializer = $serializer;
-        $this->format = $format ?: self::DEFAULT_FORMAT;
+        $this->format = $format;
     }
 
     /**
@@ -42,7 +42,7 @@ class SymfonySerializer implements Serializer
      *
      * @return string
      */
-    public function serialize($data)
+    public function serialize($data): string
     {
         return $this->serializer->serialize($data, $this->format);
     }
@@ -52,7 +52,7 @@ class SymfonySerializer implements Serializer
      *
      * @return object
      */
-    public function deserialize($data)
+    public function deserialize(string $data)
     {
         return $this->serializer->deserialize($data, Command::class, $this->format);
     }

--- a/src/Command/Queue/Serializer/SymfonySerializer.php
+++ b/src/Command/Queue/Serializer/SymfonySerializer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Queue/Serializer/SymfonySerializer.php
+++ b/src/Command/Queue/Serializer/SymfonySerializer.php
@@ -55,6 +55,12 @@ class SymfonySerializer implements Serializer
      */
     public function deserialize(string $data)
     {
-        return $this->serializer->deserialize($data, Command::class, $this->format);
+        $result = $this->serializer->deserialize($data, Command::class, $this->format);
+
+        if (!is_object($result)) {
+            throw new \RuntimeException(sprintf('Failed deserialize data "%s"', $data));
+        }
+
+        return $result;
     }
 }

--- a/src/Command/Queue/Subscribe/ExecutingSubscribeCommandQueue.php
+++ b/src/Command/Queue/Subscribe/ExecutingSubscribeCommandQueue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Queue/Subscribe/ExecutingSubscribeCommandQueue.php
+++ b/src/Command/Queue/Subscribe/ExecutingSubscribeCommandQueue.php
@@ -26,11 +26,11 @@ class ExecutingSubscribeCommandQueue implements SubscribeCommandQueue
      *
      * @return bool
      */
-    public function publish(Command $command)
+    public function publish(Command $command): bool
     {
         // absence of a handlers is not a error
         foreach ($this->handlers as $handler) {
-            call_user_func($handler, $command);
+            $handler($command);
         }
 
         return true;
@@ -41,7 +41,7 @@ class ExecutingSubscribeCommandQueue implements SubscribeCommandQueue
      *
      * @param callable $handler
      */
-    public function subscribe(callable $handler)
+    public function subscribe(callable $handler): void
     {
         $this->handlers[] = $handler;
     }
@@ -53,7 +53,7 @@ class ExecutingSubscribeCommandQueue implements SubscribeCommandQueue
      *
      * @return bool
      */
-    public function unsubscribe(callable $handler)
+    public function unsubscribe(callable $handler): bool
     {
         $index = array_search($handler, $this->handlers);
 

--- a/src/Command/Queue/Subscribe/ExecutingSubscribeCommandQueue.php
+++ b/src/Command/Queue/Subscribe/ExecutingSubscribeCommandQueue.php
@@ -57,7 +57,7 @@ class ExecutingSubscribeCommandQueue implements SubscribeCommandQueue
     {
         $index = array_search($handler, $this->handlers);
 
-        if ($index === false) {
+        if (false === $index) {
             return false;
         }
 

--- a/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
+++ b/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
@@ -91,7 +91,7 @@ class PredisSubscribeCommandQueue implements SubscribeCommandQueue
 
         // laze subscribe
         if (!$this->subscribed) {
-            $this->client->subscribe($this->queue_name, function ($message) {
+            $this->client->subscribe($this->queue_name, function ($message): void {
                 $this->handle($message);
             });
             $this->subscribed = true;

--- a/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
+++ b/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
@@ -125,6 +125,11 @@ class PredisSubscribeCommandQueue implements SubscribeCommandQueue
     {
         try {
             $command = $this->serializer->deserialize($message);
+
+            if (!($command instanceof Command)) {
+                throw new \RuntimeException(sprintf('The denormalization command is expected "%s", got "%s" inside.', Command::class, get_class($command)));
+            }
+
         } catch (\Exception $e) { // catch only deserialize exception
             // it's a critical error
             // it is necessary to react quickly to it

--- a/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
+++ b/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
@@ -129,7 +129,6 @@ class PredisSubscribeCommandQueue implements SubscribeCommandQueue
             if (!($command instanceof Command)) {
                 throw new \RuntimeException(sprintf('The denormalization command is expected "%s", got "%s" inside.', Command::class, get_class($command)));
             }
-
         } catch (\Exception $e) { // catch only deserialize exception
             // it's a critical error
             // it is necessary to react quickly to it

--- a/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
+++ b/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
@@ -109,7 +109,7 @@ class PredisSubscribeCommandQueue implements SubscribeCommandQueue
     {
         $index = array_search($handler, $this->handlers);
 
-        if ($index === false) {
+        if (false === $index) {
             return false;
         }
 

--- a/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
+++ b/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
+++ b/src/Command/Queue/Subscribe/PredisSubscribeCommandQueue.php
@@ -40,7 +40,7 @@ class PredisSubscribeCommandQueue implements SubscribeCommandQueue
     /**
      * @var string
      */
-    private $queue_name = '';
+    private $queue_name;
 
     /**
      * @var bool
@@ -57,7 +57,7 @@ class PredisSubscribeCommandQueue implements SubscribeCommandQueue
         RedisPubSubAdapter $client,
         Serializer $serializer,
         LoggerInterface $logger,
-        $queue_name
+        string $queue_name
     ) {
         $this->client = $client;
         $this->serializer = $serializer;
@@ -72,7 +72,7 @@ class PredisSubscribeCommandQueue implements SubscribeCommandQueue
      *
      * @return bool
      */
-    public function publish(Command $command)
+    public function publish(Command $command): bool
     {
         $massage = $this->serializer->serialize($command);
         $this->client->publish($this->queue_name, $massage);
@@ -85,7 +85,7 @@ class PredisSubscribeCommandQueue implements SubscribeCommandQueue
      *
      * @param callable $handler
      */
-    public function subscribe(callable $handler)
+    public function subscribe(callable $handler): void
     {
         $this->handlers[] = $handler;
 
@@ -105,7 +105,7 @@ class PredisSubscribeCommandQueue implements SubscribeCommandQueue
      *
      * @return bool
      */
-    public function unsubscribe(callable $handler)
+    public function unsubscribe(callable $handler): bool
     {
         $index = array_search($handler, $this->handlers);
 
@@ -121,7 +121,7 @@ class PredisSubscribeCommandQueue implements SubscribeCommandQueue
     /**
      * @param mixed $message
      */
-    private function handle($message)
+    private function handle($message): void
     {
         try {
             $command = $this->serializer->deserialize($message);
@@ -137,7 +137,7 @@ class PredisSubscribeCommandQueue implements SubscribeCommandQueue
         }
 
         foreach ($this->handlers as $handler) {
-            call_user_func($handler, $command);
+            $handler($command);
         }
     }
 }

--- a/src/Command/Queue/Subscribe/SubscribeCommandQueue.php
+++ b/src/Command/Queue/Subscribe/SubscribeCommandQueue.php
@@ -22,7 +22,7 @@ interface SubscribeCommandQueue extends CommandQueue
      *
      * @param callable $handler
      */
-    public function subscribe(callable $handler);
+    public function subscribe(callable $handler): void;
 
     /**
      * Unsubscribe on command queue.
@@ -31,5 +31,5 @@ interface SubscribeCommandQueue extends CommandQueue
      *
      * @return bool
      */
-    public function unsubscribe(callable $handler);
+    public function unsubscribe(callable $handler): bool;
 }

--- a/src/Command/Queue/Subscribe/SubscribeCommandQueue.php
+++ b/src/Command/Queue/Subscribe/SubscribeCommandQueue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Query/Bus/HandlerLocatedQueryBus.php
+++ b/src/Query/Bus/HandlerLocatedQueryBus.php
@@ -42,6 +42,6 @@ class HandlerLocatedQueryBus implements QueryBus
             throw HandlerNotFoundException::notFound($query);
         }
 
-        return call_user_func($handler, $query);
+        return $handler($query);
     }
 }

--- a/src/Query/Bus/HandlerLocatedQueryBus.php
+++ b/src/Query/Bus/HandlerLocatedQueryBus.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Query/Bus/QueryBus.php
+++ b/src/Query/Bus/QueryBus.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Query/Exception/HandlerNotFoundException.php
+++ b/src/Query/Exception/HandlerNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Query/Exception/HandlerNotFoundException.php
+++ b/src/Query/Exception/HandlerNotFoundException.php
@@ -12,14 +12,14 @@ namespace GpsLab\Component\Query\Exception;
 
 use GpsLab\Component\Query\Query;
 
-class HandlerNotFoundException extends \RuntimeException
+final class HandlerNotFoundException extends \RuntimeException
 {
     /**
      * @param Query $query
      *
      * @return self
      */
-    public static function notFound(Query $query)
+    public static function notFound(Query $query): self
     {
         $parts = explode('\\', get_class($query));
 

--- a/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
@@ -61,8 +61,9 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if (is_a($class_name, QuerySubscriber::class, true)) {
-            foreach (forward_static_call([$class_name, 'getSubscribedQueries']) as $query_name => $method) {
+        $get_subscribed_queries = [$class_name, 'getSubscribedQueries'];
+        if (is_callable($get_subscribed_queries) && is_a($class_name, QuerySubscriber::class, true)) {
+            foreach ($get_subscribed_queries() as $query_name => $method) {
                 $this->registerService($query_name, $service_name, $method);
             }
         }

--- a/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace GpsLab\Component\Query\Handler\Locator;
 
+use GpsLab\Component\Query\Handler\QuerySubscriber;
 use GpsLab\Component\Query\Query;
 use Psr\Container\ContainerInterface;
 
@@ -52,6 +53,21 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
     public function registerService(string $query_name, string $service, string $method = '__invoke'): void
     {
         $this->query_handler_ids[$query_name] = [$service, $method];
+    }
+
+    /**
+     * @param string $service_name
+     * @param string $class_name
+     */
+    public function registerSubscriberService(string $service_name, string $class_name): void
+    {
+        if ($class_name instanceof QuerySubscriber) {
+            foreach ($class_name::getSubscribedQueries() as $query_name => $methods) {
+                foreach ($methods as $method) {
+                    $this->registerService($query_name, $service_name, $method);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
@@ -61,8 +61,8 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if ($class_name instanceof QuerySubscriber) {
-            foreach ($class_name::getSubscribedQueries() as $query_name => $method) {
+        if (is_a($class_name, QuerySubscriber::class, true)) {
+            foreach (forward_static_call([$class_name, 'getSubscribedQueries']) as $query_name => $method) {
                 $this->registerService($query_name, $service_name, $method);
             }
         }

--- a/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
@@ -62,10 +62,8 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
         if ($class_name instanceof QuerySubscriber) {
-            foreach ($class_name::getSubscribedQueries() as $query_name => $methods) {
-                foreach ($methods as $method) {
-                    $this->registerService($query_name, $service_name, $method);
-                }
+            foreach ($class_name::getSubscribedQueries() as $query_name => $method) {
+                $this->registerService($query_name, $service_name, $method);
             }
         }
     }

--- a/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
@@ -96,8 +96,10 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
             return $service;
         }
 
-        if (is_callable([$service, $method])) {
-            return [$service, $method];
+        $handler = [$service, $method];
+
+        if (is_callable($handler)) {
+            return $handler;
         }
 
         return null;

--- a/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
@@ -38,7 +38,7 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
      *
      * @return callable|null
      */
-    public function findHandler(Query $query)
+    public function findHandler(Query $query): ?callable
     {
         return $this->lazyLoad(get_class($query));
     }
@@ -48,20 +48,20 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
      * @param string $service
      * @param string $method
      */
-    public function registerService($query_name, $service, $method = '__invoke')
+    public function registerService(string $query_name, string $service, string $method = '__invoke'): void
     {
         $this->query_handler_ids[$query_name] = [$service, $method];
     }
 
     /**
-     * @param $query_name
+     * @param string $query_name
      *
-     * @return callable
+     * @return callable|null
      */
-    private function lazyLoad($query_name)
+    private function lazyLoad(string $query_name): ?callable
     {
         if (isset($this->query_handler_ids[$query_name])) {
-            list($service, $method) = $this->query_handler_ids[$query_name];
+            [$service, $method] = $this->query_handler_ids[$query_name];
 
             return $this->resolve($this->container->get($service), $method);
         }
@@ -75,7 +75,7 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
      *
      * @return callable|null
      */
-    private function resolve($service, $method)
+    private function resolve($service, string $method): ?callable
     {
         if (is_callable($service)) {
             return $service;

--- a/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/ContainerQueryHandlerLocator.php
@@ -23,7 +23,7 @@ class ContainerQueryHandlerLocator implements QueryHandlerLocator
     private $container;
 
     /**
-     * @var array
+     * @var array[]
      */
     private $query_handler_ids = [];
 

--- a/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
@@ -37,10 +37,8 @@ class DirectBindingQueryHandlerLocator implements QueryHandlerLocator
      */
     public function registerSubscriber(QuerySubscriber $subscriber): void
     {
-        foreach ($subscriber::getSubscribedQueries() as $query_name => $methods) {
-            foreach ($methods as $method) {
-                $this->registerHandler($query_name, [$subscriber, $method]);
-            }
+        foreach ($subscriber::getSubscribedQueries() as $query_name => $method) {
+            $this->registerHandler($query_name, [$subscriber, $method]);
         }
     }
 

--- a/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
@@ -25,7 +25,7 @@ class DirectBindingQueryHandlerLocator implements QueryHandlerLocator
      * @param string   $query_name
      * @param callable $handler
      */
-    public function registerHandler($query_name, callable $handler)
+    public function registerHandler(string $query_name, callable $handler): void
     {
         $this->handlers[$query_name] = $handler;
     }
@@ -35,10 +35,8 @@ class DirectBindingQueryHandlerLocator implements QueryHandlerLocator
      *
      * @return callable|null
      */
-    public function findHandler(Query $query)
+    public function findHandler(Query $query): ?callable
     {
-        $query_name = get_class($query);
-
-        return isset($this->handlers[$query_name]) ? $this->handlers[$query_name] : null;
+        return $this->handlers[get_class($query)] ?? null;
     }
 }

--- a/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
@@ -38,7 +38,10 @@ class DirectBindingQueryHandlerLocator implements QueryHandlerLocator
     public function registerSubscriber(QuerySubscriber $subscriber): void
     {
         foreach ($subscriber::getSubscribedQueries() as $query_name => $method) {
-            $this->registerHandler($query_name, [$subscriber, $method]);
+            $handler = [$subscriber, $method];
+            if (is_callable($handler)) {
+                $this->registerHandler($query_name, $handler);
+            }
         }
     }
 

--- a/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/DirectBindingQueryHandlerLocator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace GpsLab\Component\Query\Handler\Locator;
 
+use GpsLab\Component\Query\Handler\QuerySubscriber;
 use GpsLab\Component\Query\Query;
 
 class DirectBindingQueryHandlerLocator implements QueryHandlerLocator
@@ -29,6 +30,18 @@ class DirectBindingQueryHandlerLocator implements QueryHandlerLocator
     public function registerHandler(string $query_name, callable $handler): void
     {
         $this->handlers[$query_name] = $handler;
+    }
+
+    /**
+     * @param QuerySubscriber $subscriber
+     */
+    public function registerSubscriber(QuerySubscriber $subscriber): void
+    {
+        foreach ($subscriber::getSubscribedQueries() as $query_name => $methods) {
+            foreach ($methods as $method) {
+                $this->registerHandler($query_name, [$subscriber, $method]);
+            }
+        }
     }
 
     /**

--- a/src/Query/Handler/Locator/QueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/QueryHandlerLocator.php
@@ -19,5 +19,5 @@ interface QueryHandlerLocator
      *
      * @return callable|null
      */
-    public function findHandler(Query $query);
+    public function findHandler(Query $query): ?callable;
 }

--- a/src/Query/Handler/Locator/QueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/QueryHandlerLocator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace GpsLab\Component\Query\Handler\Locator;
 
+use GpsLab\Component\Query\Handler\QuerySubscriber;
 use GpsLab\Component\Query\Query;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
@@ -43,6 +44,21 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
     public function registerService(string $query_name, string $service, string $method = '__invoke'): void
     {
         $this->query_handler_ids[$query_name] = [$service, $method];
+    }
+
+    /**
+     * @param string $service_name
+     * @param string $class_name
+     */
+    public function registerSubscriberService(string $service_name, string $class_name): void
+    {
+        if ($class_name instanceof QuerySubscriber) {
+            foreach ($class_name::getSubscribedQueries() as $query_name => $methods) {
+                foreach ($methods as $method) {
+                    $this->registerService($query_name, $service_name, $method);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
@@ -52,8 +52,8 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if ($class_name instanceof QuerySubscriber) {
-            foreach ($class_name::getSubscribedQueries() as $query_name => $method) {
+        if (is_a($class_name, QuerySubscriber::class, true)) {
+            foreach (forward_static_call([$class_name, 'getSubscribedQueries']) as $query_name => $method) {
                 $this->registerService($query_name, $service_name, $method);
             }
         }

--- a/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
@@ -22,7 +22,7 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
     use ContainerAwareTrait;
 
     /**
-     * @var array
+     * @var array[]
      */
     private $query_handler_ids = [];
 

--- a/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
@@ -52,8 +52,9 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
      */
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
-        if (is_a($class_name, QuerySubscriber::class, true)) {
-            foreach (forward_static_call([$class_name, 'getSubscribedQueries']) as $query_name => $method) {
+        $get_subscribed_queries = [$class_name, 'getSubscribedQueries'];
+        if (is_callable($get_subscribed_queries) && is_a($class_name, QuerySubscriber::class, true)) {
+            foreach ($get_subscribed_queries() as $query_name => $method) {
                 $this->registerService($query_name, $service_name, $method);
             }
         }

--- a/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
@@ -29,7 +29,7 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
      *
      * @return callable|null
      */
-    public function findHandler(Query $query)
+    public function findHandler(Query $query): ?callable
     {
         return $this->lazyLoad(get_class($query));
     }
@@ -39,20 +39,20 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
      * @param string $service
      * @param string $method
      */
-    public function registerService($query_name, $service, $method = '__invoke')
+    public function registerService(string $query_name, string $service, string $method = '__invoke'): void
     {
         $this->query_handler_ids[$query_name] = [$service, $method];
     }
 
     /**
-     * @param $query_name
+     * @param string $query_name
      *
-     * @return callable
+     * @return callable|null
      */
-    private function lazyLoad($query_name)
+    private function lazyLoad(string $query_name): ?callable
     {
         if ($this->container instanceof ContainerInterface && isset($this->query_handler_ids[$query_name])) {
-            list($service, $method) = $this->query_handler_ids[$query_name];
+            [$service, $method] = $this->query_handler_ids[$query_name];
 
             return $this->resolve($this->container->get($service), $method);
         }
@@ -66,7 +66,7 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
      *
      * @return callable|null
      */
-    private function resolve($service, $method)
+    private function resolve($service, string $method): ?callable
     {
         if (is_callable($service)) {
             return $service;

--- a/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
@@ -53,10 +53,8 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
     public function registerSubscriberService(string $service_name, string $class_name): void
     {
         if ($class_name instanceof QuerySubscriber) {
-            foreach ($class_name::getSubscribedQueries() as $query_name => $methods) {
-                foreach ($methods as $method) {
-                    $this->registerService($query_name, $service_name, $method);
-                }
+            foreach ($class_name::getSubscribedQueries() as $query_name => $method) {
+                $this->registerService($query_name, $service_name, $method);
             }
         }
     }

--- a/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
+++ b/src/Query/Handler/Locator/SymfonyContainerQueryHandlerLocator.php
@@ -87,8 +87,10 @@ class SymfonyContainerQueryHandlerLocator implements QueryHandlerLocator, Contai
             return $service;
         }
 
-        if (is_callable([$service, $method])) {
-            return [$service, $method];
+        $handler = [$service, $method];
+
+        if (is_callable($handler)) {
+            return $handler;
         }
 
         return null;

--- a/src/Query/Handler/QuerySubscriber.php
+++ b/src/Query/Handler/QuerySubscriber.php
@@ -21,7 +21,7 @@ interface QuerySubscriber
      * }
      * </code>
      *
-     * @return array
+     * @return array<class-string, string>
      */
     public static function getSubscribedQueries(): array;
 }

--- a/src/Query/Handler/QuerySubscriber.php
+++ b/src/Query/Handler/QuerySubscriber.php
@@ -16,9 +16,9 @@ interface QuerySubscriber
      * Get called methods for subscribed queries.
      *
      * <code>
-     * [
-     *  [<query_name>, <method_name>],
-     * ]
+     * {
+     *  <query_name>: <method_name>,
+     * }
      * </code>
      *
      * @return array

--- a/src/Query/Handler/QuerySubscriber.php
+++ b/src/Query/Handler/QuerySubscriber.php
@@ -17,7 +17,7 @@ interface QuerySubscriber
      *
      * <code>
      * [
-     *  [<query_name>, [<method,. ..>]],
+     *  [<query_name>, <method_name>],
      * ]
      * </code>
      *

--- a/src/Query/Handler/QuerySubscriber.php
+++ b/src/Query/Handler/QuerySubscriber.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * GpsLab component.
+ *
+ * @author    Peter Gribanov <info@peter-gribanov.ru>
+ * @copyright Copyright (c) 2011, Peter Gribanov
+ * @license   http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Query\Handler;
+
+interface QuerySubscriber
+{
+    /**
+     * Get called methods for subscribed queries.
+     *
+     * <code>
+     * [
+     *  [<query_name>, [<method,. ..>]],
+     * ]
+     * </code>
+     *
+     * @return array
+     */
+    public static function getSubscribedQueries(): array;
+}

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Command/Bus/HandlerLocatedCommandBusTest.php
+++ b/tests/Command/Bus/HandlerLocatedCommandBusTest.php
@@ -52,7 +52,7 @@ class HandlerLocatedCommandBusTest extends TestCase
             ->expects($this->once())
             ->method('findHandler')
             ->with($this->command)
-            ->will($this->returnValue($handler))
+            ->willReturn($handler)
         ;
 
         $this->bus->handle($this->command);
@@ -67,7 +67,7 @@ class HandlerLocatedCommandBusTest extends TestCase
             ->expects($this->once())
             ->method('findHandler')
             ->with($this->command)
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $this->bus->handle($this->command);

--- a/tests/Command/Bus/HandlerLocatedCommandBusTest.php
+++ b/tests/Command/Bus/HandlerLocatedCommandBusTest.php
@@ -41,10 +41,10 @@ class HandlerLocatedCommandBusTest extends TestCase
         $this->bus = new HandlerLocatedCommandBus($this->locator);
     }
 
-    public function testHandle()
+    public function testHandle(): void
     {
         $handled_command = null;
-        $handler = function (Command $command) use (&$handled_command) {
+        $handler = static function (Command $command) use (&$handled_command): void {
             $handled_command = $command;
         };
 
@@ -59,7 +59,7 @@ class HandlerLocatedCommandBusTest extends TestCase
         $this->assertEquals($this->command, $handled_command);
     }
 
-    public function testNoHandler()
+    public function testNoHandler(): void
     {
         $this->expectException(HandlerNotFoundException::class);
 

--- a/tests/Command/Bus/HandlerLocatedCommandBusTest.php
+++ b/tests/Command/Bus/HandlerLocatedCommandBusTest.php
@@ -12,8 +12,8 @@ namespace GpsLab\Component\Tests\Command\Bus;
 
 use GpsLab\Component\Command\Bus\HandlerLocatedCommandBus;
 use GpsLab\Component\Command\Command;
-use GpsLab\Component\Command\Handler\Locator\CommandHandlerLocator;
 use GpsLab\Component\Command\Exception\HandlerNotFoundException;
+use GpsLab\Component\Command\Handler\Locator\CommandHandlerLocator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Command/Bus/HandlerLocatedCommandBusTest.php
+++ b/tests/Command/Bus/HandlerLocatedCommandBusTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Command/Bus/HandlerLocatedCommandBusTest.php
+++ b/tests/Command/Bus/HandlerLocatedCommandBusTest.php
@@ -56,7 +56,7 @@ class HandlerLocatedCommandBusTest extends TestCase
         ;
 
         $this->bus->handle($this->command);
-        $this->assertEquals($this->command, $handled_command);
+        $this->assertSame($this->command, $handled_command);
     }
 
     public function testNoHandler()

--- a/tests/Command/Bus/HandlerLocatedCommandBusTest.php
+++ b/tests/Command/Bus/HandlerLocatedCommandBusTest.php
@@ -13,17 +13,19 @@ namespace GpsLab\Component\Tests\Command\Bus;
 use GpsLab\Component\Command\Bus\HandlerLocatedCommandBus;
 use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Handler\Locator\CommandHandlerLocator;
+use GpsLab\Component\Command\Exception\HandlerNotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class HandlerLocatedCommandBusTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|CommandHandlerLocator
+     * @var MockObject|CommandHandlerLocator
      */
     private $locator;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Command
+     * @var MockObject|Command
      */
     private $command;
 
@@ -32,10 +34,10 @@ class HandlerLocatedCommandBusTest extends TestCase
      */
     private $bus;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->command = $this->getMock(Command::class);
-        $this->locator = $this->getMock(CommandHandlerLocator::class);
+        $this->command = $this->createMock(Command::class);
+        $this->locator = $this->createMock(CommandHandlerLocator::class);
         $this->bus = new HandlerLocatedCommandBus($this->locator);
     }
 
@@ -57,11 +59,10 @@ class HandlerLocatedCommandBusTest extends TestCase
         $this->assertEquals($this->command, $handled_command);
     }
 
-    /**
-     * @expectedException \GpsLab\Component\Command\Exception\HandlerNotFoundException
-     */
     public function testNoHandler()
     {
+        $this->expectException(HandlerNotFoundException::class);
+
         $this->locator
             ->expects($this->once())
             ->method('findHandler')

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -95,7 +95,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
         $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
-        call_user_func($handler, $command);
+        $handler($command);
         $this->assertSame($command, $handler_obj->command());
     }
 

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -14,7 +14,9 @@ namespace GpsLab\Component\Tests\Command\Handler\Locator;
 use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Handler\Locator\ContainerCommandHandlerLocator;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
+use GpsLab\Component\Tests\Fixture\Command\Handler\ContestCommandSubscriber;
 use GpsLab\Component\Tests\Fixture\Command\Handler\CreateContactHandler;
+use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -69,6 +71,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($this->command);
+        $this->assertIsCallable($handler);
         $this->assertSame($this->handler, $handler);
     }
 
@@ -93,6 +96,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($command);
+        $this->assertIsCallable($handler);
         $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
@@ -138,5 +142,33 @@ class ContainerCommandHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler($this->command);
         $this->assertNull($handler);
+    }
+
+    public function testRegisterSubscriber(): void
+    {
+        $service = 'foo';
+        $subscriber = new ContestCommandSubscriber();
+
+        $this->container
+            ->expects($this->exactly(3))
+            ->method('get')
+            ->with($service)
+            ->willReturn($subscriber)
+        ;
+
+        $this->locator->registerSubscriberService($service, get_class($subscriber));
+
+        $handler = $this->locator->findHandler(new CreateContact());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onCreate'], $handler);
+
+        // double call ContainerInterface::get()
+        $handler = $this->locator->findHandler(new CreateContact());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onCreate'], $handler);
+
+        $handler = $this->locator->findHandler(new RenameContactCommand());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onRename'], $handler);
     }
 }

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -10,13 +10,13 @@
 
 namespace GpsLab\Component\Tests\Command\Handler\Locator;
 
-use GpsLab\Component\Command\Handler\Locator\ContainerCommandHandlerLocator;
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\Locator\ContainerCommandHandlerLocator;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\Handler\CreateContactHandler;
-use Psr\Container\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 class ContainerCommandHandlerLocatorTest extends TestCase
 {

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -58,7 +58,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
             ->expects($this->exactly(2))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue($this->handler))
+            ->willReturn($this->handler)
         ;
 
         $this->locator->registerService(get_class($this->command), $service);
@@ -82,7 +82,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
             ->expects($this->exactly(2))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue($handler_obj))
+            ->willReturn($handler_obj)
         ;
 
         $this->locator->registerService(CreateContact::class, $service, $method);
@@ -107,7 +107,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
             ->expects($this->exactly(1))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $this->locator->registerService(get_class($this->command), $service);
@@ -130,7 +130,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
             ->expects($this->exactly(1))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue(new \stdClass()))
+            ->willReturn(new \stdClass())
         ;
 
         $this->locator->registerService(get_class($this->command), $service);

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -104,7 +104,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
         $service = 'foo';
 
         $this->container
-            ->expects($this->exactly(1))
+            ->expects($this->once())
             ->method('get')
             ->with($service)
             ->will($this->returnValue(null))
@@ -127,7 +127,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
         $service = 'foo';
 
         $this->container
-            ->expects($this->exactly(1))
+            ->expects($this->once())
             ->method('get')
             ->with($service)
             ->will($this->returnValue(new \stdClass()))

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -160,15 +160,15 @@ class ContainerCommandHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         $handler = $this->locator->findHandler(new RenameContactCommand());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onRename'], $handler);
+        $this->assertSame([$subscriber, 'handleRename'], $handler);
     }
 }

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -44,7 +44,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
     {
         $this->command = $this->createMock(Command::class);
         $this->handler = function (Command $command) {
-            $this->assertEquals($command, $this->command);
+            $this->assertSame($command, $this->command);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new ContainerCommandHandlerLocator($this->container);
@@ -64,11 +64,11 @@ class ContainerCommandHandlerLocatorTest extends TestCase
         $this->locator->registerService(get_class($this->command), $service);
 
         $handler = $this->locator->findHandler($this->command);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($this->command);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testFindHandlerServiceInvoke()
@@ -88,15 +88,15 @@ class ContainerCommandHandlerLocatorTest extends TestCase
         $this->locator->registerService(CreateContact::class, $service, $method);
 
         $handler = $this->locator->findHandler($command);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($command);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
         call_user_func($handler, $command);
-        $this->assertEquals($command, $handler_obj->command());
+        $this->assertSame($command, $handler_obj->command());
     }
 
     public function testNoCommandHandler()

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -15,17 +15,18 @@ use GpsLab\Component\Command\Command;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\Handler\CreateContactHandler;
 use Psr\Container\ContainerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ContainerCommandHandlerLocatorTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface
+     * @var MockObject|ContainerInterface
      */
     private $container;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Command
+     * @var MockObject|Command
      */
     private $command;
 
@@ -39,14 +40,13 @@ class ContainerCommandHandlerLocatorTest extends TestCase
      */
     private $locator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->command = $this->getMock(Command::class);
+        $this->command = $this->createMock(Command::class);
         $this->handler = function (Command $command) {
             $this->assertEquals($command, $this->command);
         };
-        $this->container = $this->getMock(ContainerInterface::class);
-
+        $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new ContainerCommandHandlerLocator($this->container);
     }
 

--- a/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/ContainerCommandHandlerLocatorTest.php
@@ -43,14 +43,14 @@ class ContainerCommandHandlerLocatorTest extends TestCase
     protected function setUp(): void
     {
         $this->command = $this->createMock(Command::class);
-        $this->handler = function (Command $command) {
+        $this->handler = function (Command $command): void {
             $this->assertEquals($command, $this->command);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new ContainerCommandHandlerLocator($this->container);
     }
 
-    public function testFindHandler()
+    public function testFindHandler(): void
     {
         $service = 'foo';
 
@@ -71,7 +71,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
         $this->assertEquals($this->handler, $handler);
     }
 
-    public function testFindHandlerServiceInvoke()
+    public function testFindHandlerServiceInvoke(): void
     {
         $service = 'foo';
         $command = new CreateContact();
@@ -99,7 +99,7 @@ class ContainerCommandHandlerLocatorTest extends TestCase
         $this->assertEquals($command, $handler_obj->command());
     }
 
-    public function testNoCommandHandler()
+    public function testNoCommandHandler(): void
     {
         $service = 'foo';
 
@@ -116,13 +116,13 @@ class ContainerCommandHandlerLocatorTest extends TestCase
         $this->assertNull($handler);
     }
 
-    public function testNoAnyCommandHandler()
+    public function testNoAnyCommandHandler(): void
     {
         $handler = $this->locator->findHandler($this->command);
         $this->assertNull($handler);
     }
 
-    public function testHandlerIsNotACommandHandler()
+    public function testHandlerIsNotACommandHandler(): void
     {
         $service = 'foo';
 

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -63,7 +63,6 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
 
     public function testRegisterSubscriber(): void
     {
-        $service = 'foo';
         $subscriber = new ContestCommandSubscriber();
 
         $this->locator->registerSubscriber($subscriber);

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -69,15 +69,15 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         $handler = $this->locator->findHandler(new RenameContactCommand());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onRename'], $handler);
+        $this->assertSame([$subscriber, 'handleRename'], $handler);
     }
 }

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -35,13 +35,13 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
     protected function setUp(): void
     {
         $this->command = $this->createMock(Command::class);
-        $this->handler = function (Command $command) {
+        $this->handler = function (Command $command): void {
             $this->assertEquals($command, $this->command);
         };
         $this->locator = new DirectBindingCommandHandlerLocator();
     }
 
-    public function testFindHandler()
+    public function testFindHandler(): void
     {
         $this->locator->registerHandler(get_class($this->command), $this->handler);
 
@@ -49,7 +49,7 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
         $this->assertEquals($this->handler, $handler);
     }
 
-    public function testNoCommandHandler()
+    public function testNoCommandHandler(): void
     {
         $this->locator->registerHandler('foo', $this->handler);
 

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -36,7 +36,7 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
     {
         $this->command = $this->createMock(Command::class);
         $this->handler = function (Command $command) {
-            $this->assertEquals($command, $this->command);
+            $this->assertSame($command, $this->command);
         };
         $this->locator = new DirectBindingCommandHandlerLocator();
     }
@@ -46,7 +46,7 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
         $this->locator->registerHandler(get_class($this->command), $this->handler);
 
         $handler = $this->locator->findHandler($this->command);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testNoCommandHandler()

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 namespace GpsLab\Component\Tests\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\Handler\ContestCommandSubscriber;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
-use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -12,12 +12,13 @@ namespace GpsLab\Component\Tests\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 use GpsLab\Component\Command\Command;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class DirectBindingCommandHandlerLocatorTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Command
+     * @var MockObject|Command
      */
     private $command;
 
@@ -31,13 +32,12 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
      */
     private $locator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->command = $this->getMock(Command::class);
+        $this->command = $this->createMock(Command::class);
         $this->handler = function (Command $command) {
             $this->assertEquals($command, $this->command);
         };
-
         $this->locator = new DirectBindingCommandHandlerLocator();
     }
 

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -10,8 +10,8 @@
 
 namespace GpsLab\Component\Tests\Command\Handler\Locator;
 
-use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/DirectBindingCommandHandlerLocatorTest.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 namespace GpsLab\Component\Tests\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Tests\Fixture\Command\CreateContact;
+use GpsLab\Component\Tests\Fixture\Command\Handler\ContestCommandSubscriber;
+use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use GpsLab\Component\Command\Handler\Locator\DirectBindingCommandHandlerLocator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -56,5 +59,26 @@ class DirectBindingCommandHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler($this->command);
         $this->assertNull($handler);
+    }
+
+    public function testRegisterSubscriber(): void
+    {
+        $service = 'foo';
+        $subscriber = new ContestCommandSubscriber();
+
+        $this->locator->registerSubscriber($subscriber);
+
+        $handler = $this->locator->findHandler(new CreateContact());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onCreate'], $handler);
+
+        // double call ContainerInterface::get()
+        $handler = $this->locator->findHandler(new CreateContact());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onCreate'], $handler);
+
+        $handler = $this->locator->findHandler(new RenameContactCommand());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'onRename'], $handler);
     }
 }

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -44,7 +44,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
     {
         $this->command = $this->createMock(Command::class);
         $this->handler = function (Command $command) {
-            $this->assertEquals($command, $this->command);
+            $this->assertSame($command, $this->command);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new SymfonyContainerCommandHandlerLocator();
@@ -65,11 +65,11 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $this->locator->registerService(get_class($this->command), $service);
 
         $handler = $this->locator->findHandler($this->command);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($this->command);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testFindHandlerServiceInvoke()
@@ -90,15 +90,15 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $this->locator->registerService(RenameContactCommand::class, $service, $method);
 
         $handler = $this->locator->findHandler($command);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($command);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
         call_user_func($handler, $command);
-        $this->assertEquals($command, $handler_obj->command());
+        $this->assertSame($command, $handler_obj->command());
     }
 
     public function testNoCommandHandler()

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -43,14 +43,14 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
     protected function setUp(): void
     {
         $this->command = $this->createMock(Command::class);
-        $this->handler = function (Command $command) {
+        $this->handler = function (Command $command): void {
             $this->assertEquals($command, $this->command);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new SymfonyContainerCommandHandlerLocator();
     }
 
-    public function testFindHandler()
+    public function testFindHandler(): void
     {
         $this->locator->setContainer($this->container);
         $service = 'foo';
@@ -72,7 +72,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $this->assertEquals($this->handler, $handler);
     }
 
-    public function testFindHandlerServiceInvoke()
+    public function testFindHandlerServiceInvoke(): void
     {
         $this->locator->setContainer($this->container);
         $service = 'foo';
@@ -101,7 +101,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $this->assertEquals($command, $handler_obj->command());
     }
 
-    public function testNoCommandHandler()
+    public function testNoCommandHandler(): void
     {
         $this->locator->setContainer($this->container);
         $service = 'foo';
@@ -119,7 +119,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $this->assertNull($handler);
     }
 
-    public function testHandlerIsNotACommandHandler()
+    public function testHandlerIsNotACommandHandler(): void
     {
         $this->locator->setContainer($this->container);
         $service = 'foo';
@@ -137,14 +137,14 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $this->assertNull($handler);
     }
 
-    public function testNoAnyCommandHandler()
+    public function testNoAnyCommandHandler(): void
     {
         $this->locator->setContainer($this->container);
         $handler = $this->locator->findHandler($this->command);
         $this->assertNull($handler);
     }
 
-    public function testNoContainer()
+    public function testNoContainer(): void
     {
         $service = 'foo';
 

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 namespace GpsLab\Component\Tests\Command\Handler\Locator;
 
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\Handler\ContestCommandSubscriber;
-use GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator;
 use GpsLab\Component\Tests\Fixture\Command\Handler\RenameContactHandler;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -97,7 +97,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
-        call_user_func($handler, $command);
+        $handler($command);
         $this->assertSame($command, $handler_obj->command());
     }
 

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -174,15 +174,15 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler(new CreateContact());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onCreate'], $handler);
+        $this->assertSame([$subscriber, 'handleCreate'], $handler);
 
         $handler = $this->locator->findHandler(new RenameContactCommand());
         $this->assertIsCallable($handler);
-        $this->assertSame([$subscriber, 'onRename'], $handler);
+        $this->assertSame([$subscriber, 'handleRename'], $handler);
     }
 }

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -10,13 +10,13 @@
 
 namespace GpsLab\Component\Tests\Command\Handler\Locator;
 
-use GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator;
 use GpsLab\Component\Command\Command;
+use GpsLab\Component\Command\Handler\Locator\SymfonyContainerCommandHandlerLocator;
 use GpsLab\Component\Tests\Fixture\Command\Handler\RenameContactHandler;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class SymfonyContainerCommandHandlerLocatorTest extends TestCase
 {

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -59,7 +59,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
             ->expects($this->exactly(2))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue($this->handler))
+            ->willReturn($this->handler)
         ;
 
         $this->locator->registerService(get_class($this->command), $service);
@@ -84,7 +84,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
             ->expects($this->exactly(2))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue($handler_obj))
+            ->willReturn($handler_obj)
         ;
 
         $this->locator->registerService(RenameContactCommand::class, $service, $method);
@@ -110,7 +110,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
             ->expects($this->exactly(1))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $this->locator->registerService(get_class($this->command), $service);
@@ -128,7 +128,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
             ->expects($this->exactly(1))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue(new \stdClass()))
+            ->willReturn(new \stdClass())
         ;
 
         $this->locator->registerService(get_class($this->command), $service);

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -15,17 +15,18 @@ use GpsLab\Component\Command\Command;
 use GpsLab\Component\Tests\Fixture\Command\Handler\RenameContactHandler;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SymfonyContainerCommandHandlerLocatorTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface
+     * @var MockObject|ContainerInterface
      */
     private $container;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Command
+     * @var MockObject|Command
      */
     private $command;
 
@@ -39,14 +40,13 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
      */
     private $locator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->command = $this->getMock(Command::class);
+        $this->command = $this->createMock(Command::class);
         $this->handler = function (Command $command) {
             $this->assertEquals($command, $this->command);
         };
-        $this->container = $this->getMock(ContainerInterface::class);
-
+        $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new SymfonyContainerCommandHandlerLocator();
     }
 

--- a/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
+++ b/tests/Command/Handler/Locator/SymfonyContainerCommandHandlerLocatorTest.php
@@ -107,7 +107,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $service = 'foo';
 
         $this->container
-            ->expects($this->exactly(1))
+            ->expects($this->once())
             ->method('get')
             ->with($service)
             ->will($this->returnValue(null))
@@ -125,7 +125,7 @@ class SymfonyContainerCommandHandlerLocatorTest extends TestCase
         $service = 'foo';
 
         $this->container
-            ->expects($this->exactly(1))
+            ->expects($this->once())
             ->method('get')
             ->with($service)
             ->will($this->returnValue(new \stdClass()))

--- a/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
@@ -42,10 +42,10 @@ class MemoryPullCommandQueueTest extends TestCase
         $expected = array_reverse($queue);
         $i = count($expected);
         while ($command = $this->queue->pull()) {
-            $this->assertEquals($expected[--$i], $command);
+            $this->assertSame($expected[--$i], $command);
         }
 
-        $this->assertEquals(0, $i, 'Queue cleared');
+        $this->assertSame(0, $i, 'Queue cleared');
         $this->assertNull($command, 'No commands in queue');
     }
 }

--- a/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
@@ -22,7 +22,7 @@ class MemoryPullCommandQueueTest extends TestCase
      */
     private $queue;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->queue = new MemoryPullCommandQueue();
     }

--- a/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryPullCommandQueueTest.php
@@ -27,7 +27,7 @@ class MemoryPullCommandQueueTest extends TestCase
         $this->queue = new MemoryPullCommandQueue();
     }
 
-    public function testQueue()
+    public function testQueue(): void
     {
         $queue = [
             new CreateContact(),

--- a/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
@@ -27,7 +27,7 @@ class MemoryUniquePullCommandQueueTest extends TestCase
         $this->queue = new MemoryUniquePullCommandQueue();
     }
 
-    public function testQueue()
+    public function testQueue(): void
     {
         $queue = [
             new CreateContact(),

--- a/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
@@ -22,7 +22,7 @@ class MemoryUniquePullCommandQueueTest extends TestCase
      */
     private $queue;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->queue = new MemoryUniquePullCommandQueue();
     }

--- a/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/MemoryUniquePullCommandQueueTest.php
@@ -51,7 +51,7 @@ class MemoryUniquePullCommandQueueTest extends TestCase
             $this->assertEquals($expected[--$i], $command);
         }
 
-        $this->assertEquals(0, $i, 'Queue cleared');
+        $this->assertSame(0, $i, 'Queue cleared');
         $this->assertNull($command, 'No commands in queue');
     }
 }

--- a/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
@@ -70,14 +70,14 @@ class PredisPullCommandQueueTest extends TestCase
                 ->expects($this->at($i))
                 ->method('serialize')
                 ->with($command)
-                ->will($this->returnValue($value))
+                ->willReturn($value)
             ;
 
             $this->client
                 ->expects($this->at($i))
                 ->method('__call')
                 ->with('rpush', [$this->queue_name, [$value]])
-                ->will($this->returnValue(1))
+                ->willReturn(1)
             ;
             ++$i;
         }
@@ -103,14 +103,14 @@ class PredisPullCommandQueueTest extends TestCase
                 ->expects($this->at($i))
                 ->method('deserialize')
                 ->with($value)
-                ->will($this->returnValue($command))
+                ->willReturn($command)
             ;
 
             $this->client
                 ->expects($this->at($i))
                 ->method('__call')
                 ->with('lpop', [$this->queue_name])
-                ->will($this->returnValue($value))
+                ->willReturn($value)
             ;
             ++$i;
         }
@@ -118,7 +118,7 @@ class PredisPullCommandQueueTest extends TestCase
             ->expects($this->at($i))
             ->method('__call')
             ->with('lpop', [$this->queue_name])
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $expected = array_reverse($queue);
@@ -141,27 +141,27 @@ class PredisPullCommandQueueTest extends TestCase
             ->expects($this->at(0))
             ->method('__call')
             ->with('lpop', [$this->queue_name])
-            ->will($this->returnValue($value))
+            ->willReturn($value)
         ;
         $this->client
             ->expects($this->at(1))
             ->method('__call')
             ->with('rpush', [$this->queue_name, [$value]])
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
 
         $this->serializer
             ->expects($this->once())
             ->method('deserialize')
             ->with($value)
-            ->will($this->throwException($exception))
+            ->willThrowException($exception)
         ;
 
         $this->logger
             ->expects($this->once())
             ->method('critical')
             ->with('Failed denormalize a command in the Redis queue', [$value, $exception->getMessage()])
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
 
         $this->assertNull($this->queue->pull());

--- a/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
@@ -54,7 +54,7 @@ class PredisPullCommandQueueTest extends TestCase
         $this->queue = new PredisPullCommandQueue($this->client, $this->serializer, $this->logger, $this->queue_name);
     }
 
-    public function testPushQueue()
+    public function testPushQueue(): void
     {
         $queue = [
             new RenameContactCommand(),
@@ -87,7 +87,7 @@ class PredisPullCommandQueueTest extends TestCase
         }
     }
 
-    public function testPopQueue()
+    public function testPopQueue(): void
     {
         $queue = [
             new RenameContactCommand(),
@@ -131,7 +131,7 @@ class PredisPullCommandQueueTest extends TestCase
         $this->assertNull($command, 'No commands in queue');
     }
 
-    public function testFailedDeserialize()
+    public function testFailedDeserialize(): void
     {
         $exception = new \Exception('foo');
         $command = new RenameContactCommand();

--- a/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
@@ -15,10 +15,10 @@ use GpsLab\Component\Command\Queue\Pull\PredisPullCommandQueue;
 use GpsLab\Component\Command\Queue\Serializer\Serializer;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
-use Predis\Client;
-use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Predis\Client;
+use Psr\Log\LoggerInterface;
 
 class PredisPullCommandQueueTest extends TestCase
 {

--- a/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
@@ -10,6 +10,7 @@
 
 namespace GpsLab\Component\Tests\Command\Queue\Pull;
 
+use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Queue\Pull\PredisPullCommandQueue;
 use GpsLab\Component\Command\Queue\Serializer\Serializer;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
@@ -131,7 +132,7 @@ class PredisPullCommandQueueTest extends TestCase
         $this->assertNull($command, 'No commands in queue');
     }
 
-    public function testFailedDeserialize(): void
+    public function testErrorOnDeserialize(): void
     {
         $exception = new \Exception('foo');
         $command = new RenameContactCommand();
@@ -161,6 +162,47 @@ class PredisPullCommandQueueTest extends TestCase
             ->expects($this->once())
             ->method('critical')
             ->with('Failed denormalize a command in the Redis queue', [$value, $exception->getMessage()])
+            ->willReturn(1)
+        ;
+
+        $this->assertNull($this->queue->pull());
+    }
+
+    public function testDeserializeBadResult(): void
+    {
+        $result = new \stdClass();
+        $command = new RenameContactCommand();
+        $value = spl_object_hash($command);
+        $message = sprintf(
+            'The denormalization command is expected "%s", got "%s" inside.',
+            Command::class,
+            \stdClass::class
+        );
+
+        $this->client
+            ->expects($this->at(0))
+            ->method('__call')
+            ->with('lpop', [$this->queue_name])
+            ->willReturn($value)
+        ;
+        $this->client
+            ->expects($this->at(1))
+            ->method('__call')
+            ->with('rpush', [$this->queue_name, [$value]])
+            ->willReturn(1)
+        ;
+
+        $this->serializer
+            ->expects($this->once())
+            ->method('deserialize')
+            ->with($value)
+            ->willReturn($result)
+        ;
+
+        $this->logger
+            ->expects($this->once())
+            ->method('critical')
+            ->with('Failed denormalize a command in the Redis queue', [$value, $message])
             ->willReturn(1)
         ;
 

--- a/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
@@ -16,22 +16,23 @@ use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use Predis\Client;
 use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class PredisPullCommandQueueTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Client
+     * @var MockObject|Client
      */
     private $client;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Serializer
+     * @var MockObject|Serializer
      */
     private $serializer;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|LoggerInterface
+     * @var MockObject|LoggerInterface
      */
     private $logger;
 
@@ -45,11 +46,11 @@ class PredisPullCommandQueueTest extends TestCase
      */
     private $queue_name = 'commands';
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->client = $this->getMock(Client::class);
-        $this->serializer = $this->getMock(Serializer::class);
-        $this->logger = $this->getMock(LoggerInterface::class);
+        $this->client = $this->createMock(Client::class);
+        $this->serializer = $this->createMock(Serializer::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->queue = new PredisPullCommandQueue($this->client, $this->serializer, $this->logger, $this->queue_name);
     }
 

--- a/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
@@ -24,7 +24,7 @@ use Psr\Log\LoggerInterface;
 class PredisPullCommandQueueTest extends TestCase
 {
     /**
-     * @var MockObject|Client
+     * @var MockObject|Client<Client>
      */
     private $client;
 

--- a/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisPullCommandQueueTest.php
@@ -124,10 +124,10 @@ class PredisPullCommandQueueTest extends TestCase
         $expected = array_reverse($queue);
         $i = count($expected);
         while ($command = $this->queue->pull()) {
-            $this->assertEquals($expected[--$i], $command);
+            $this->assertSame($expected[--$i], $command);
         }
 
-        $this->assertEquals(0, $i, 'Queue cleared');
+        $this->assertSame(0, $i, 'Queue cleared');
         $this->assertNull($command, 'No commands in queue');
     }
 

--- a/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
@@ -24,7 +24,7 @@ use Psr\Log\LoggerInterface;
 class PredisUniquePullCommandQueueTest extends TestCase
 {
     /**
-     * @var MockObject|Client
+     * @var MockObject|Client<Client>
      */
     private $client;
 

--- a/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
@@ -10,6 +10,7 @@
 
 namespace GpsLab\Component\Tests\Command\Queue\Pull;
 
+use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Queue\Pull\PredisUniquePullCommandQueue;
 use GpsLab\Component\Command\Queue\Serializer\Serializer;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
@@ -145,7 +146,7 @@ class PredisUniquePullCommandQueueTest extends TestCase
         $this->assertNull($command, 'No commands in queue');
     }
 
-    public function testFailedDeserialize(): void
+    public function testErrorOnDeserialize(): void
     {
         $exception = new \Exception('foo');
         $command = new RenameContactCommand();
@@ -175,6 +176,47 @@ class PredisUniquePullCommandQueueTest extends TestCase
             ->expects($this->once())
             ->method('critical')
             ->with('Failed denormalize a command in the Redis queue', [$value, $exception->getMessage()])
+            ->willReturn(1)
+        ;
+
+        $this->assertNull($this->queue->pull());
+    }
+
+    public function testDeserializeBadResult(): void
+    {
+        $result = new \stdClass();
+        $command = new RenameContactCommand();
+        $value = spl_object_hash($command);
+        $message = sprintf(
+            'The denormalization command is expected "%s", got "%s" inside.',
+            Command::class,
+            \stdClass::class
+        );
+
+        $this->client
+            ->expects($this->at(0))
+            ->method('__call')
+            ->with('lpop', [$this->queue_name])
+            ->willReturn($value)
+        ;
+        $this->client
+            ->expects($this->at(1))
+            ->method('__call')
+            ->with('rpush', [$this->queue_name, [$value]])
+            ->willReturn(1)
+        ;
+
+        $this->serializer
+            ->expects($this->once())
+            ->method('deserialize')
+            ->with($value)
+            ->willReturn($result)
+        ;
+
+        $this->logger
+            ->expects($this->once())
+            ->method('critical')
+            ->with('Failed denormalize a command in the Redis queue', [$value, $message])
             ->willReturn(1)
         ;
 

--- a/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
@@ -138,10 +138,10 @@ class PredisUniquePullCommandQueueTest extends TestCase
         $expected = array_reverse($queue);
         $i = count($expected);
         while ($command = $this->queue->pull()) {
-            $this->assertEquals($expected[--$i], $command);
+            $this->assertSame($expected[--$i], $command);
         }
 
-        $this->assertEquals(0, $i, 'Queue cleared');
+        $this->assertSame(0, $i, 'Queue cleared');
         $this->assertNull($command, 'No commands in queue');
     }
 

--- a/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
@@ -15,10 +15,10 @@ use GpsLab\Component\Command\Queue\Pull\PredisUniquePullCommandQueue;
 use GpsLab\Component\Command\Queue\Serializer\Serializer;
 use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
-use Predis\Client;
-use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Predis\Client;
+use Psr\Log\LoggerInterface;
 
 class PredisUniquePullCommandQueueTest extends TestCase
 {

--- a/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
@@ -59,7 +59,7 @@ class PredisUniquePullCommandQueueTest extends TestCase
         );
     }
 
-    public function testPushQueue()
+    public function testPushQueue(): void
     {
         $queue = [
             new RenameContactCommand(),
@@ -101,7 +101,7 @@ class PredisUniquePullCommandQueueTest extends TestCase
         }
     }
 
-    public function testPopQueue()
+    public function testPopQueue(): void
     {
         $queue = [
             new RenameContactCommand(),
@@ -145,7 +145,7 @@ class PredisUniquePullCommandQueueTest extends TestCase
         $this->assertNull($command, 'No commands in queue');
     }
 
-    public function testFailedDeserialize()
+    public function testFailedDeserialize(): void
     {
         $exception = new \Exception('foo');
         $command = new RenameContactCommand();

--- a/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
@@ -78,20 +78,20 @@ class PredisUniquePullCommandQueueTest extends TestCase
                 ->expects($this->at($i))
                 ->method('serialize')
                 ->with($command)
-                ->will($this->returnValue($value))
+                ->willReturn($value)
             ;
 
             $this->client
                 ->expects($this->at($i * 2))
                 ->method('__call')
                 ->with('lrem', [$this->queue_name, 0, $value])
-                ->will($this->returnValue(1))
+                ->willReturn(1)
             ;
             $this->client
                 ->expects($this->at((($i + 1) * 2) - 1))
                 ->method('__call')
                 ->with('rpush', [$this->queue_name, [$value]])
-                ->will($this->returnValue(1))
+                ->willReturn(1)
             ;
             ++$i;
         }
@@ -117,14 +117,14 @@ class PredisUniquePullCommandQueueTest extends TestCase
                 ->expects($this->at($i))
                 ->method('deserialize')
                 ->with($value)
-                ->will($this->returnValue($command))
+                ->willReturn($command)
             ;
 
             $this->client
                 ->expects($this->at($i))
                 ->method('__call')
                 ->with('lpop', [$this->queue_name])
-                ->will($this->returnValue($value))
+                ->willReturn($value)
             ;
             ++$i;
         }
@@ -132,7 +132,7 @@ class PredisUniquePullCommandQueueTest extends TestCase
             ->expects($this->at($i))
             ->method('__call')
             ->with('lpop', [$this->queue_name])
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $expected = array_reverse($queue);
@@ -155,27 +155,27 @@ class PredisUniquePullCommandQueueTest extends TestCase
             ->expects($this->at(0))
             ->method('__call')
             ->with('lpop', [$this->queue_name])
-            ->will($this->returnValue($value))
+            ->willReturn($value)
         ;
         $this->client
             ->expects($this->at(1))
             ->method('__call')
             ->with('rpush', [$this->queue_name, [$value]])
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
 
         $this->serializer
             ->expects($this->once())
             ->method('deserialize')
             ->with($value)
-            ->will($this->throwException($exception))
+            ->willThrowException($exception)
         ;
 
         $this->logger
             ->expects($this->once())
             ->method('critical')
             ->with('Failed denormalize a command in the Redis queue', [$value, $exception->getMessage()])
-            ->will($this->returnValue(1))
+            ->willReturn(1)
         ;
 
         $this->assertNull($this->queue->pull());

--- a/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
+++ b/tests/Command/Queue/Pull/PredisUniquePullCommandQueueTest.php
@@ -16,22 +16,23 @@ use GpsLab\Component\Tests\Fixture\Command\CreateContact;
 use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 use Predis\Client;
 use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class PredisUniquePullCommandQueueTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Client
+     * @var MockObject|Client
      */
     private $client;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Serializer
+     * @var MockObject|Serializer
      */
     private $serializer;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|LoggerInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|LoggerInterface
      */
     private $logger;
 
@@ -45,11 +46,11 @@ class PredisUniquePullCommandQueueTest extends TestCase
      */
     private $queue_name = 'unique_commands';
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->client = $this->getMock(Client::class);
-        $this->serializer = $this->getMock(Serializer::class);
-        $this->logger = $this->getMock(LoggerInterface::class);
+        $this->client = $this->createMock(Client::class);
+        $this->serializer = $this->createMock(Serializer::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->queue = new PredisUniquePullCommandQueue(
             $this->client,
             $this->serializer,

--- a/tests/Command/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Command/Queue/Serializer/SymfonySerializerTest.php
@@ -57,7 +57,11 @@ class SymfonySerializerTest extends TestCase
             ->will($this->returnValue($result))
         ;
 
-        $serializer = new SymfonySerializer($this->serializer, $format);
+        if ($format) {
+            $serializer = new SymfonySerializer($this->serializer, $format);
+        } else {
+            $serializer = new SymfonySerializer($this->serializer);
+        }
 
         $this->assertEquals($result, $serializer->serialize($data));
     }
@@ -80,7 +84,11 @@ class SymfonySerializerTest extends TestCase
             ->will($this->returnValue($result))
         ;
 
-        $serializer = new SymfonySerializer($this->serializer, $format);
+        if ($format) {
+            $serializer = new SymfonySerializer($this->serializer, $format);
+        } else {
+            $serializer = new SymfonySerializer($this->serializer);
+        }
 
         $this->assertEquals($result, $serializer->deserialize($data));
     }

--- a/tests/Command/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Command/Queue/Serializer/SymfonySerializerTest.php
@@ -31,7 +31,7 @@ class SymfonySerializerTest extends TestCase
     /**
      * @return array
      */
-    public function formats()
+    public function formats(): array
     {
         return [
             [null, 'predis'],
@@ -42,10 +42,10 @@ class SymfonySerializerTest extends TestCase
     /**
      * @dataProvider formats
      *
-     * @param string $format
-     * @param string $expected_format
+     * @param string|null $format
+     * @param string      $expected_format
      */
-    public function testSerialize($format, $expected_format)
+    public function testSerialize(?string $format, string $expected_format): void
     {
         $data = new \stdClass();
         $result = 'foo';
@@ -65,10 +65,10 @@ class SymfonySerializerTest extends TestCase
     /**
      * @dataProvider formats
      *
-     * @param string $format
-     * @param string $expected_format
+     * @param string|null $format
+     * @param string      $expected_format
      */
-    public function testDeserialize($format, $expected_format)
+    public function testDeserialize(?string $format, string $expected_format): void
     {
         $data = 'foo';
         $result = new \stdClass();

--- a/tests/Command/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Command/Queue/Serializer/SymfonySerializerTest.php
@@ -30,7 +30,7 @@ class SymfonySerializerTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return array[]
      */
     public function formats(): array
     {

--- a/tests/Command/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Command/Queue/Serializer/SymfonySerializerTest.php
@@ -13,18 +13,19 @@ namespace  GpsLab\Component\Tests\Command\Queue\Serializer;
 use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Queue\Serializer\SymfonySerializer;
 use Symfony\Component\Serializer\SerializerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SymfonySerializerTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|SerializerInterface
+     * @var MockObject|SerializerInterface
      */
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->serializer = $this->getMock(SerializerInterface::class);
+        $this->serializer = $this->createMock(SerializerInterface::class);
     }
 
     /**

--- a/tests/Command/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Command/Queue/Serializer/SymfonySerializerTest.php
@@ -93,4 +93,33 @@ class SymfonySerializerTest extends TestCase
 
         $this->assertSame($result, $serializer->deserialize($data));
     }
+
+    /**
+     * @dataProvider formats
+     *
+     * @param string|null $format
+     * @param string      $expected_format
+     */
+    public function testFailedDeserialize(?string $format, string $expected_format): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $data = 'foo';
+        $result = 'bar';
+
+        $this->serializer
+            ->expects($this->once())
+            ->method('deserialize')
+            ->with($data, Command::class, $expected_format)
+            ->willReturn($result)
+        ;
+
+        if ($format) {
+            $serializer = new SymfonySerializer($this->serializer, $format);
+        } else {
+            $serializer = new SymfonySerializer($this->serializer);
+        }
+
+        $serializer->deserialize($data);
+    }
 }

--- a/tests/Command/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Command/Queue/Serializer/SymfonySerializerTest.php
@@ -54,7 +54,7 @@ class SymfonySerializerTest extends TestCase
             ->expects($this->once())
             ->method('serialize')
             ->with($data, $expected_format)
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
 
         $serializer = new SymfonySerializer($this->serializer, $format);
@@ -77,7 +77,7 @@ class SymfonySerializerTest extends TestCase
             ->expects($this->once())
             ->method('deserialize')
             ->with($data, Command::class, $expected_format)
-            ->will($this->returnValue($result))
+            ->willReturn($result)
         ;
 
         $serializer = new SymfonySerializer($this->serializer, $format);

--- a/tests/Command/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Command/Queue/Serializer/SymfonySerializerTest.php
@@ -12,9 +12,9 @@ namespace  GpsLab\Component\Tests\Command\Queue\Serializer;
 
 use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Queue\Serializer\SymfonySerializer;
-use Symfony\Component\Serializer\SerializerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\SerializerInterface;
 
 class SymfonySerializerTest extends TestCase
 {

--- a/tests/Command/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Command/Queue/Serializer/SymfonySerializerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Command/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Command/Queue/Serializer/SymfonySerializerTest.php
@@ -59,7 +59,7 @@ class SymfonySerializerTest extends TestCase
 
         $serializer = new SymfonySerializer($this->serializer, $format);
 
-        $this->assertEquals($result, $serializer->serialize($data));
+        $this->assertSame($result, $serializer->serialize($data));
     }
 
     /**
@@ -82,6 +82,6 @@ class SymfonySerializerTest extends TestCase
 
         $serializer = new SymfonySerializer($this->serializer, $format);
 
-        $this->assertEquals($result, $serializer->deserialize($data));
+        $this->assertSame($result, $serializer->deserialize($data));
     }
 }

--- a/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
@@ -38,7 +38,7 @@ class ExecutingSubscribeCommandQueueTest extends TestCase
         $subscriber_called = false;
         $handler = function ($command) use (&$subscriber_called) {
             $this->assertInstanceOf(Command::class, $command);
-            $this->assertEquals($this->command, $command);
+            $this->assertSame($this->command, $command);
             $subscriber_called = true;
         };
 

--- a/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
@@ -33,10 +33,10 @@ class ExecutingSubscribeCommandQueueTest extends TestCase
         $this->queue = new ExecutingSubscribeCommandQueue();
     }
 
-    public function testPublish()
+    public function testPublish(): void
     {
         $subscriber_called = false;
-        $handler = function ($command) use (&$subscriber_called) {
+        $handler = function ($command) use (&$subscriber_called): void {
             $this->assertInstanceOf(Command::class, $command);
             $this->assertEquals($this->command, $command);
             $subscriber_called = true;

--- a/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/ExecutingSubscribeCommandQueueTest.php
@@ -12,12 +12,13 @@ namespace GpsLab\Component\Tests\Command\Queue\Subscribe;
 
 use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Queue\Subscribe\ExecutingSubscribeCommandQueue;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ExecutingSubscribeCommandQueueTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Command
+     * @var MockObject|Command
      */
     private $command;
 
@@ -26,9 +27,9 @@ class ExecutingSubscribeCommandQueueTest extends TestCase
      */
     private $queue;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->command = $this->getMock(Command::class);
+        $this->command = $this->createMock(Command::class);
         $this->queue = new ExecutingSubscribeCommandQueue();
     }
 

--- a/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
@@ -14,10 +14,10 @@ use Exception;
 use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Queue\Serializer\Serializer;
 use GpsLab\Component\Command\Queue\Subscribe\PredisSubscribeCommandQueue;
-use Psr\Log\LoggerInterface;
-use Superbalist\PubSub\Redis\RedisPubSubAdapter;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Superbalist\PubSub\Redis\RedisPubSubAdapter;
 
 class PredisSubscribeCommandQueueTest extends TestCase
 {

--- a/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
@@ -98,7 +98,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $subscriber_called = false;
         $handler = function ($command) use (&$subscriber_called) {
             $this->assertInstanceOf(Command::class, $command);
-            $this->assertEquals($this->command, $command);
+            $this->assertSame($this->command, $command);
             $subscriber_called = true;
         };
 
@@ -106,8 +106,8 @@ class PredisSubscribeCommandQueueTest extends TestCase
             ->expects($this->once())
             ->method('subscribe')
             ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
-                $this->assertEquals($this->queue_name, $queue_name);
-                $this->assertTrue(is_callable($handler_wrapper));
+                $this->assertSame($this->queue_name, $queue_name);
+                $this->assertIsCallable($handler_wrapper);
 
                 $message = 'foo';
                 $this->serializer
@@ -131,7 +131,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $subscriber_called = false;
         $handler = function ($command) use (&$subscriber_called) {
             $this->assertInstanceOf(Command::class, $command);
-            $this->assertEquals($this->command, $command);
+            $this->assertSame($this->command, $command);
             $subscriber_called = true;
         };
 
@@ -139,8 +139,8 @@ class PredisSubscribeCommandQueueTest extends TestCase
             ->expects($this->once())
             ->method('subscribe')
             ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
-                $this->assertEquals($this->queue_name, $queue_name);
-                $this->assertTrue(is_callable($handler_wrapper));
+                $this->assertSame($this->queue_name, $queue_name);
+                $this->assertIsCallable($handler_wrapper);
 
                 $exception = new \Exception('bar');
                 $message = 'foo';
@@ -182,7 +182,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $exception = new \Exception('bar');
         $handler = function ($command) use ($exception) {
             $this->assertInstanceOf(Command::class, $command);
-            $this->assertEquals($this->command, $command);
+            $this->assertSame($this->command, $command);
 
             throw $exception;
         };
@@ -191,8 +191,8 @@ class PredisSubscribeCommandQueueTest extends TestCase
             ->expects($this->once())
             ->method('subscribe')
             ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
-                $this->assertEquals($this->queue_name, $queue_name);
-                $this->assertTrue(is_callable($handler_wrapper));
+                $this->assertSame($this->queue_name, $queue_name);
+                $this->assertIsCallable($handler_wrapper);
 
                 $message = 'foo';
                 $this->serializer
@@ -213,7 +213,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
     {
         $handler1 = function ($command) {
             $this->assertInstanceOf(Command::class, $command);
-            $this->assertEquals($this->command, $command);
+            $this->assertSame($this->command, $command);
         };
         $handler2 = function (Command $command) {
         };

--- a/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
@@ -81,7 +81,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
             ->expects($this->once())
             ->method('serialize')
             ->with($this->command)
-            ->will($this->returnValue($massage))
+            ->willReturn($massage)
         ;
 
         $this->client
@@ -105,7 +105,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('subscribe')
-            ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
+            ->willReturnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
                 $this->assertEquals($this->queue_name, $queue_name);
                 $this->assertTrue(is_callable($handler_wrapper));
 
@@ -114,11 +114,11 @@ class PredisSubscribeCommandQueueTest extends TestCase
                     ->expects($this->once())
                     ->method('deserialize')
                     ->with($message)
-                    ->will($this->returnValue($this->command))
+                    ->willReturn($this->command)
                 ;
 
                 call_user_func($handler_wrapper, $message);
-            }))
+            })
         ;
 
         $this->queue->subscribe($handler);
@@ -138,7 +138,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('subscribe')
-            ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
+            ->willReturnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
                 $this->assertEquals($this->queue_name, $queue_name);
                 $this->assertTrue(is_callable($handler_wrapper));
 
@@ -148,7 +148,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
                     ->expects($this->once())
                     ->method('deserialize')
                     ->with($message)
-                    ->will($this->throwException($exception))
+                    ->willThrowException($exception)
                 ;
 
                 $this->logger
@@ -167,7 +167,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
                 ;
 
                 call_user_func($handler_wrapper, $message);
-            }))
+            })
         ;
 
         $this->queue->subscribe($handler);
@@ -190,7 +190,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('subscribe')
-            ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
+            ->willReturnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
                 $this->assertEquals($this->queue_name, $queue_name);
                 $this->assertTrue(is_callable($handler_wrapper));
 
@@ -199,11 +199,11 @@ class PredisSubscribeCommandQueueTest extends TestCase
                     ->expects($this->once())
                     ->method('deserialize')
                     ->with($message)
-                    ->will($this->returnValue($this->command))
+                    ->willReturn($this->command)
                 ;
 
                 call_user_func($handler_wrapper, $message);
-            }))
+            })
         ;
 
         $this->queue->subscribe($handler);

--- a/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
@@ -10,32 +10,34 @@
 
 namespace GpsLab\Component\Tests\Command\Queue\Subscribe;
 
+use Exception;
 use GpsLab\Component\Command\Command;
 use GpsLab\Component\Command\Queue\Serializer\Serializer;
 use GpsLab\Component\Command\Queue\Subscribe\PredisSubscribeCommandQueue;
 use Psr\Log\LoggerInterface;
 use Superbalist\PubSub\Redis\RedisPubSubAdapter;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class PredisSubscribeCommandQueueTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Command
+     * @var MockObject|Command
      */
     private $command;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|RedisPubSubAdapter
+     * @var MockObject|RedisPubSubAdapter
      */
     private $client;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Serializer
+     * @var MockObject|Serializer
      */
     private $serializer;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|LoggerInterface
+     * @var MockObject|LoggerInterface
      */
     private $logger;
 
@@ -49,15 +51,15 @@ class PredisSubscribeCommandQueueTest extends TestCase
      */
     private $queue_name = 'commands';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!class_exists(RedisPubSubAdapter::class)) {
             $this->markTestSkipped('php-pubsub-redis is not installed.');
         }
 
-        $this->command = $this->getMock(Command::class);
-        $this->serializer = $this->getMock(Serializer::class);
-        $this->logger = $this->getMock(LoggerInterface::class);
+        $this->command = $this->createMock(Command::class);
+        $this->serializer = $this->createMock(Serializer::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->client = $this
             ->getMockBuilder(RedisPubSubAdapter::class)
             ->disableOriginalConstructor()
@@ -173,11 +175,10 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->assertFalse($subscriber_called);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testSubscribeHandlerFailure()
     {
+        $this->expectException(Exception::class);
+
         $exception = new \Exception('bar');
         $handler = function ($command) use ($exception) {
             $this->assertInstanceOf(Command::class, $command);

--- a/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
@@ -73,7 +73,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         );
     }
 
-    public function testPublish()
+    public function testPublish(): void
     {
         $massage = 'foo';
 
@@ -93,10 +93,10 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->assertTrue($this->queue->publish($this->command));
     }
 
-    public function testSubscribe()
+    public function testSubscribe(): void
     {
         $subscriber_called = false;
-        $handler = function ($command) use (&$subscriber_called) {
+        $handler = function ($command) use (&$subscriber_called): void {
             $this->assertInstanceOf(Command::class, $command);
             $this->assertEquals($this->command, $command);
             $subscriber_called = true;
@@ -105,7 +105,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('subscribe')
-            ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
+            ->will($this->returnCallback(function ($queue_name, $handler_wrapper): void {
                 $this->assertEquals($this->queue_name, $queue_name);
                 $this->assertTrue(is_callable($handler_wrapper));
 
@@ -117,7 +117,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
                     ->will($this->returnValue($this->command))
                 ;
 
-                call_user_func($handler_wrapper, $message);
+                $handler_wrapper($message);
             }))
         ;
 
@@ -126,10 +126,10 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->assertTrue($subscriber_called);
     }
 
-    public function testSubscribeFailure()
+    public function testSubscribeFailure(): void
     {
         $subscriber_called = false;
-        $handler = function ($command) use (&$subscriber_called) {
+        $handler = function ($command) use (&$subscriber_called): void {
             $this->assertInstanceOf(Command::class, $command);
             $this->assertEquals($this->command, $command);
             $subscriber_called = true;
@@ -138,7 +138,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('subscribe')
-            ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
+            ->will($this->returnCallback(function ($queue_name, $handler_wrapper): void {
                 $this->assertEquals($this->queue_name, $queue_name);
                 $this->assertTrue(is_callable($handler_wrapper));
 
@@ -166,7 +166,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
                     ->with($this->queue_name, $message)
                 ;
 
-                call_user_func($handler_wrapper, $message);
+                $handler_wrapper($message);
             }))
         ;
 
@@ -175,12 +175,12 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->assertFalse($subscriber_called);
     }
 
-    public function testSubscribeHandlerFailure()
+    public function testSubscribeHandlerFailure(): void
     {
         $this->expectException(Exception::class);
 
         $exception = new \Exception('bar');
-        $handler = function ($command) use ($exception) {
+        $handler = function ($command) use ($exception): void {
             $this->assertInstanceOf(Command::class, $command);
             $this->assertEquals($this->command, $command);
 
@@ -190,7 +190,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('subscribe')
-            ->will($this->returnCallback(function ($queue_name, $handler_wrapper) use ($handler) {
+            ->will($this->returnCallback(function ($queue_name, $handler_wrapper): void {
                 $this->assertEquals($this->queue_name, $queue_name);
                 $this->assertTrue(is_callable($handler_wrapper));
 
@@ -202,20 +202,20 @@ class PredisSubscribeCommandQueueTest extends TestCase
                     ->will($this->returnValue($this->command))
                 ;
 
-                call_user_func($handler_wrapper, $message);
+                $handler_wrapper($message);
             }))
         ;
 
         $this->queue->subscribe($handler);
     }
 
-    public function testLazeSubscribe()
+    public function testLazeSubscribe(): void
     {
-        $handler1 = function ($command) {
+        $handler1 = function ($command): void {
             $this->assertInstanceOf(Command::class, $command);
             $this->assertEquals($this->command, $command);
         };
-        $handler2 = function (Command $command) {
+        $handler2 = static function (Command $command): void {
         };
 
         $this->client

--- a/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
@@ -106,7 +106,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('subscribe')
-            ->willReturnCallback(function ($queue_name, $handler_wrapper) use ($handler): void {
+            ->willReturnCallback(function ($queue_name, $handler_wrapper): void {
                 $this->assertSame($this->queue_name, $queue_name);
                 $this->assertIsCallable($handler_wrapper);
 
@@ -139,7 +139,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('subscribe')
-            ->willReturnCallback(function ($queue_name, $handler_wrapper) use ($handler): void {
+            ->willReturnCallback(function ($queue_name, $handler_wrapper): void {
                 $this->assertSame($this->queue_name, $queue_name);
                 $this->assertIsCallable($handler_wrapper);
 
@@ -245,7 +245,7 @@ class PredisSubscribeCommandQueueTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('subscribe')
-            ->willReturnCallback(function ($queue_name, $handler_wrapper) use ($handler): void {
+            ->willReturnCallback(function ($queue_name, $handler_wrapper): void {
                 $this->assertSame($this->queue_name, $queue_name);
                 $this->assertIsCallable($handler_wrapper);
 

--- a/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
+++ b/tests/Command/Queue/Subscribe/PredisSubscribeCommandQueueTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Fixture/Command/CreateContact.php
+++ b/tests/Fixture/Command/CreateContact.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
+++ b/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
@@ -18,55 +18,29 @@ use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 class ContestCommandSubscriber implements CommandSubscriber
 {
     /**
-     * @var CreateContact|null
-     */
-    private $create_contact_command;
-
-    /**
-     * @var RenameContactCommand|null
-     */
-    private $rename_contact_command;
-
-    /**
      * @return array
      */
     public static function getSubscribedCommands(): array
     {
         return [
-            CreateContact::class => 'onCreate',
-            RenameContactCommand::class => 'onRename',
+            CreateContact::class => 'handleCreate',
+            RenameContactCommand::class => 'handleRename',
         ];
     }
 
     /**
      * @param CreateContact $command
      */
-    public function onCreate(CreateContact $command): void
+    public function handleCreate(CreateContact $command): void
     {
-        $this->create_contact_command = $command;
+        // do something
     }
 
     /**
      * @param RenameContactCommand $command
      */
-    public function onRename(RenameContactCommand $command): void
+    public function handleRename(RenameContactCommand $command): void
     {
-        $this->rename_contact_command = $command;
-    }
-
-    /**
-     * @return CreateContact|null
-     */
-    public function getCreateContactCommand(): ?CreateContact
-    {
-        return $this->create_contact_command;
-    }
-
-    /**
-     * @return RenameContactCommand|null
-     */
-    public function getRenameContactCommand(): ?RenameContactCommand
-    {
-        return $this->rename_contact_command;
+        // do something
     }
 }

--- a/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
+++ b/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
@@ -1,6 +1,13 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * GpsLab component.
+ *
+ * @author    Peter Gribanov <info@peter-gribanov.ru>
+ * @copyright Copyright (c) 2011, Peter Gribanov
+ * @license   http://opensource.org/licenses/MIT
+ */
 
 namespace GpsLab\Component\Tests\Fixture\Command\Handler;
 

--- a/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
+++ b/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
@@ -18,7 +18,7 @@ use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
 class ContestCommandSubscriber implements CommandSubscriber
 {
     /**
-     * @return array
+     * @return array<class-string, string>
      */
     public static function getSubscribedCommands(): array
     {

--- a/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
+++ b/tests/Fixture/Command/Handler/ContestCommandSubscriber.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+
+namespace GpsLab\Component\Tests\Fixture\Command\Handler;
+
+use GpsLab\Component\Command\Handler\CommandSubscriber;
+use GpsLab\Component\Tests\Fixture\Command\CreateContact;
+use GpsLab\Component\Tests\Fixture\Command\RenameContactCommand;
+
+class ContestCommandSubscriber implements CommandSubscriber
+{
+    /**
+     * @var CreateContact|null
+     */
+    private $create_contact_command;
+
+    /**
+     * @var RenameContactCommand|null
+     */
+    private $rename_contact_command;
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedCommands(): array
+    {
+        return [
+            CreateContact::class => 'onCreate',
+            RenameContactCommand::class => 'onRename',
+        ];
+    }
+
+    /**
+     * @param CreateContact $command
+     */
+    public function onCreate(CreateContact $command): void
+    {
+        $this->create_contact_command = $command;
+    }
+
+    /**
+     * @param RenameContactCommand $command
+     */
+    public function onRename(RenameContactCommand $command): void
+    {
+        $this->rename_contact_command = $command;
+    }
+
+    /**
+     * @return CreateContact|null
+     */
+    public function getCreateContactCommand(): ?CreateContact
+    {
+        return $this->create_contact_command;
+    }
+
+    /**
+     * @return RenameContactCommand|null
+     */
+    public function getRenameContactCommand(): ?RenameContactCommand
+    {
+        return $this->rename_contact_command;
+    }
+}

--- a/tests/Fixture/Command/Handler/CreateContactHandler.php
+++ b/tests/Fixture/Command/Handler/CreateContactHandler.php
@@ -22,7 +22,7 @@ class CreateContactHandler
     /**
      * @param CreateContact $command
      */
-    public function handleCreateContact(CreateContact $command)
+    public function handleCreateContact(CreateContact $command): void
     {
         $this->command = $command;
     }
@@ -30,7 +30,7 @@ class CreateContactHandler
     /**
      * @return CreateContact|null
      */
-    public function command()
+    public function command(): ?CreateContact
     {
         return $this->command;
     }

--- a/tests/Fixture/Command/Handler/CreateContactHandler.php
+++ b/tests/Fixture/Command/Handler/CreateContactHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Fixture/Command/Handler/RenameContactHandler.php
+++ b/tests/Fixture/Command/Handler/RenameContactHandler.php
@@ -22,7 +22,7 @@ class RenameContactHandler
     /**
      * @param RenameContactCommand $command
      */
-    public function handleRenameContact(RenameContactCommand $command)
+    public function handleRenameContact(RenameContactCommand $command): void
     {
         $this->command = $command;
     }
@@ -30,7 +30,7 @@ class RenameContactHandler
     /**
      * @return RenameContactCommand|null
      */
-    public function command()
+    public function command(): ?RenameContactCommand
     {
         return $this->command;
     }

--- a/tests/Fixture/Command/Handler/RenameContactHandler.php
+++ b/tests/Fixture/Command/Handler/RenameContactHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Fixture/Command/RenameContactCommand.php
+++ b/tests/Fixture/Command/RenameContactCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Fixture/Query/ContactByIdentity.php
+++ b/tests/Fixture/Query/ContactByIdentity.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Fixture/Query/ContactByNameQuery.php
+++ b/tests/Fixture/Query/ContactByNameQuery.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Fixture/Query/Handler/ContactByIdentityHandler.php
+++ b/tests/Fixture/Query/Handler/ContactByIdentityHandler.php
@@ -22,7 +22,7 @@ class ContactByIdentityHandler
     /**
      * @param ContactByIdentity $query
      */
-    public function handleContactByIdentity(ContactByIdentity $query)
+    public function handleContactByIdentity(ContactByIdentity $query): void
     {
         $this->query = $query;
     }
@@ -30,7 +30,7 @@ class ContactByIdentityHandler
     /**
      * @return ContactByIdentity|null
      */
-    public function query()
+    public function query(): ?ContactByIdentity
     {
         return $this->query;
     }

--- a/tests/Fixture/Query/Handler/ContactByIdentityHandler.php
+++ b/tests/Fixture/Query/Handler/ContactByIdentityHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Fixture/Query/Handler/ContactByNameHandler.php
+++ b/tests/Fixture/Query/Handler/ContactByNameHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Fixture/Query/Handler/ContactByNameHandler.php
+++ b/tests/Fixture/Query/Handler/ContactByNameHandler.php
@@ -22,7 +22,7 @@ class ContactByNameHandler
     /**
      * @param ContactByNameQuery $query
      */
-    public function handleContactByName(ContactByNameQuery $query)
+    public function handleContactByName(ContactByNameQuery $query): void
     {
         $this->query = $query;
     }
@@ -30,7 +30,7 @@ class ContactByNameHandler
     /**
      * @return ContactByNameQuery|null
      */
-    public function query()
+    public function query(): ?ContactByNameQuery
     {
         return $this->query;
     }

--- a/tests/Fixture/Query/Handler/ContestQuerySubscriber.php
+++ b/tests/Fixture/Query/Handler/ContestQuerySubscriber.php
@@ -19,7 +19,7 @@ use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
 class ContestQuerySubscriber implements QuerySubscriber
 {
     /**
-     * @return array
+     * @return array<class-string, string>
      */
     public static function getSubscribedQueries(): array
     {

--- a/tests/Fixture/Query/Handler/ContestQuerySubscriber.php
+++ b/tests/Fixture/Query/Handler/ContestQuerySubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * GpsLab component.
+ *
+ * @author    Peter Gribanov <info@peter-gribanov.ru>
+ * @copyright Copyright (c) 2011, Peter Gribanov
+ * @license   http://opensource.org/licenses/MIT
+ */
+
+namespace GpsLab\Component\Tests\Fixture\Query\Handler;
+
+use GpsLab\Component\Query\Handler\QuerySubscriber;
+use GpsLab\Component\Tests\Fixture\Query\ContactByIdentity;
+use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
+
+class ContestQuerySubscriber implements QuerySubscriber
+{
+    /**
+     * @return array
+     */
+    public static function getSubscribedQueries(): array
+    {
+        return [
+            ContactByIdentity::class => 'getByIdentity',
+            ContactByNameQuery::class => 'getByNameQuery',
+        ];
+    }
+
+    /**
+     * @param ContactByIdentity $query
+     *
+     * @return string
+     */
+    public function getByIdentity(ContactByIdentity $query): string
+    {
+        return get_class($query);
+    }
+
+    /**
+     * @param ContactByNameQuery $query
+     *
+     * @return string
+     */
+    public function getByNameQuery(ContactByNameQuery $query): string
+    {
+        return get_class($query);
+    }
+}

--- a/tests/Fixture/Query/Handler/ContestQuerySubscriber.php
+++ b/tests/Fixture/Query/Handler/ContestQuerySubscriber.php
@@ -36,6 +36,7 @@ class ContestQuerySubscriber implements QuerySubscriber
      */
     public function getByIdentity(ContactByIdentity $query): string
     {
+        // return some data
         return get_class($query);
     }
 
@@ -46,6 +47,7 @@ class ContestQuerySubscriber implements QuerySubscriber
      */
     public function getByNameQuery(ContactByNameQuery $query): string
     {
+        // return some data
         return get_class($query);
     }
 }

--- a/tests/Query/Bus/HandlerLocatedQueryBusTest.php
+++ b/tests/Query/Bus/HandlerLocatedQueryBusTest.php
@@ -62,7 +62,7 @@ class HandlerLocatedQueryBusTest extends TestCase
             ->expects($this->once())
             ->method('findHandler')
             ->with($this->query)
-            ->will($this->returnValue($handler))
+            ->willReturn($handler)
         ;
 
         $this->assertEquals($data, $this->bus->handle($this->query));
@@ -77,7 +77,7 @@ class HandlerLocatedQueryBusTest extends TestCase
             ->expects($this->once())
             ->method('findHandler')
             ->with($this->query)
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $this->bus->handle($this->query);

--- a/tests/Query/Bus/HandlerLocatedQueryBusTest.php
+++ b/tests/Query/Bus/HandlerLocatedQueryBusTest.php
@@ -42,18 +42,18 @@ class HandlerLocatedQueryBusTest extends TestCase
     protected function setUp(): void
     {
         $this->query = $this->createMock(Query::class);
-        $this->handler = function (Query $query) {
+        $this->handler = function (Query $query): void {
             $this->assertEquals($this->query, $query);
         };
         $this->locator = $this->createMock(QueryHandlerLocator::class);
         $this->bus = new HandlerLocatedQueryBus($this->locator);
     }
 
-    public function testDispatch()
+    public function testDispatch(): void
     {
         $data = 'foo';
         $handled_query = null;
-        $handler = function (Query $query) use (&$handled_query, $data) {
+        $handler = static function (Query $query) use (&$handled_query, $data): string {
             $handled_query = $query;
 
             return $data;
@@ -69,7 +69,7 @@ class HandlerLocatedQueryBusTest extends TestCase
         $this->assertEquals($this->query, $handled_query);
     }
 
-    public function testNoHandler()
+    public function testNoHandler(): void
     {
         $this->expectException(HandlerNotFoundException::class);
 

--- a/tests/Query/Bus/HandlerLocatedQueryBusTest.php
+++ b/tests/Query/Bus/HandlerLocatedQueryBusTest.php
@@ -11,9 +11,9 @@
 namespace GpsLab\Component\Tests\Query\Bus;
 
 use GpsLab\Component\Query\Bus\HandlerLocatedQueryBus;
-use GpsLab\Component\Query\Query;
-use GpsLab\Component\Query\Handler\Locator\QueryHandlerLocator;
 use GpsLab\Component\Query\Exception\HandlerNotFoundException;
+use GpsLab\Component\Query\Handler\Locator\QueryHandlerLocator;
+use GpsLab\Component\Query\Query;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Query/Bus/HandlerLocatedQueryBusTest.php
+++ b/tests/Query/Bus/HandlerLocatedQueryBusTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Query/Bus/HandlerLocatedQueryBusTest.php
+++ b/tests/Query/Bus/HandlerLocatedQueryBusTest.php
@@ -13,17 +13,19 @@ namespace GpsLab\Component\Tests\Query\Bus;
 use GpsLab\Component\Query\Bus\HandlerLocatedQueryBus;
 use GpsLab\Component\Query\Query;
 use GpsLab\Component\Query\Handler\Locator\QueryHandlerLocator;
+use GpsLab\Component\Query\Exception\HandlerNotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class HandlerLocatedQueryBusTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|QueryHandlerLocator
+     * @var MockObject|QueryHandlerLocator
      */
     private $locator;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Query
+     * @var MockObject|Query
      */
     private $query;
 
@@ -37,13 +39,13 @@ class HandlerLocatedQueryBusTest extends TestCase
      */
     private $bus;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->query = $this->getMock(Query::class);
+        $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
             $this->assertEquals($this->query, $query);
         };
-        $this->locator = $this->getMock(QueryHandlerLocator::class);
+        $this->locator = $this->createMock(QueryHandlerLocator::class);
         $this->bus = new HandlerLocatedQueryBus($this->locator);
     }
 
@@ -67,11 +69,10 @@ class HandlerLocatedQueryBusTest extends TestCase
         $this->assertEquals($this->query, $handled_query);
     }
 
-    /**
-     * @expectedException \GpsLab\Component\Query\Exception\HandlerNotFoundException
-     */
     public function testNoHandler()
     {
+        $this->expectException(HandlerNotFoundException::class);
+
         $this->locator
             ->expects($this->once())
             ->method('findHandler')

--- a/tests/Query/Bus/HandlerLocatedQueryBusTest.php
+++ b/tests/Query/Bus/HandlerLocatedQueryBusTest.php
@@ -43,7 +43,7 @@ class HandlerLocatedQueryBusTest extends TestCase
     {
         $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
-            $this->assertEquals($this->query, $query);
+            $this->assertSame($this->query, $query);
         };
         $this->locator = $this->createMock(QueryHandlerLocator::class);
         $this->bus = new HandlerLocatedQueryBus($this->locator);
@@ -65,8 +65,8 @@ class HandlerLocatedQueryBusTest extends TestCase
             ->will($this->returnValue($handler))
         ;
 
-        $this->assertEquals($data, $this->bus->handle($this->query));
-        $this->assertEquals($this->query, $handled_query);
+        $this->assertSame($data, $this->bus->handle($this->query));
+        $this->assertSame($this->query, $handled_query);
     }
 
     public function testNoHandler()

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -44,7 +44,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
     {
         $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
-            $this->assertEquals($query, $this->query);
+            $this->assertSame($query, $this->query);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new ContainerQueryHandlerLocator($this->container);
@@ -64,11 +64,11 @@ class ContainerQueryHandlerLocatorTest extends TestCase
         $this->locator->registerService(get_class($this->query), $service);
 
         $handler = $this->locator->findHandler($this->query);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($this->query);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testFindHandlerServiceInvoke()
@@ -88,15 +88,15 @@ class ContainerQueryHandlerLocatorTest extends TestCase
         $this->locator->registerService(ContactByIdentity::class, $service, $method);
 
         $handler = $this->locator->findHandler($query);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($query);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
         call_user_func($handler, $query);
-        $this->assertEquals($query, $handler_obj->query());
+        $this->assertSame($query, $handler_obj->query());
     }
 
     public function testNoQueryHandler()

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -95,7 +95,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
         $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
-        call_user_func($handler, $query);
+        $handler($query);
         $this->assertSame($query, $handler_obj->query());
     }
 

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -58,7 +58,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
             ->expects($this->exactly(2))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue($this->handler))
+            ->willReturn($this->handler)
         ;
 
         $this->locator->registerService(get_class($this->query), $service);
@@ -82,7 +82,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
             ->expects($this->exactly(2))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue($handler_obj))
+            ->willReturn($handler_obj)
         ;
 
         $this->locator->registerService(ContactByIdentity::class, $service, $method);
@@ -107,7 +107,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
             ->expects($this->exactly(1))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $this->locator->registerService(get_class($this->query), $service);
@@ -130,7 +130,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
             ->expects($this->exactly(1))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue(new \stdClass()))
+            ->willReturn(new \stdClass())
         ;
 
         $this->locator->registerService(get_class($this->query), $service);

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -17,7 +17,6 @@ use GpsLab\Component\Tests\Fixture\Query\ContactByIdentity;
 use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContactByIdentityHandler;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContestQuerySubscriber;
-use Psr\Container\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -104,7 +104,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
         $service = 'foo';
 
         $this->container
-            ->expects($this->exactly(1))
+            ->expects($this->once())
             ->method('get')
             ->with($service)
             ->will($this->returnValue(null))
@@ -127,7 +127,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
         $service = 'foo';
 
         $this->container
-            ->expects($this->exactly(1))
+            ->expects($this->once())
             ->method('get')
             ->with($service)
             ->will($this->returnValue(new \stdClass()))

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -14,9 +14,9 @@ use GpsLab\Component\Query\Handler\Locator\ContainerQueryHandlerLocator;
 use GpsLab\Component\Query\Query;
 use GpsLab\Component\Tests\Fixture\Query\ContactByIdentity;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContactByIdentityHandler;
-use Psr\Container\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 class ContainerQueryHandlerLocatorTest extends TestCase
 {

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -15,17 +15,18 @@ use GpsLab\Component\Query\Query;
 use GpsLab\Component\Tests\Fixture\Query\ContactByIdentity;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContactByIdentityHandler;
 use Psr\Container\ContainerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ContainerQueryHandlerLocatorTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface
+     * @var MockObject|ContainerInterface
      */
     private $container;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Query
+     * @var MockObject|Query
      */
     private $query;
 
@@ -39,14 +40,13 @@ class ContainerQueryHandlerLocatorTest extends TestCase
      */
     private $locator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->query = $this->getMock(Query::class);
+        $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
             $this->assertEquals($query, $this->query);
         };
-        $this->container = $this->getMock(ContainerInterface::class);
-
+        $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new ContainerQueryHandlerLocator($this->container);
     }
 

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -14,7 +14,10 @@ namespace GpsLab\Component\Tests\Query\Handler\Locator;
 use GpsLab\Component\Query\Handler\Locator\ContainerQueryHandlerLocator;
 use GpsLab\Component\Query\Query;
 use GpsLab\Component\Tests\Fixture\Query\ContactByIdentity;
+use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContactByIdentityHandler;
+use GpsLab\Component\Tests\Fixture\Query\Handler\ContestQuerySubscriber;
+use Psr\Container\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -138,5 +141,33 @@ class ContainerQueryHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler($this->query);
         $this->assertNull($handler);
+    }
+
+    public function testRegisterSubscriber(): void
+    {
+        $service = 'foo';
+        $subscriber = new ContestQuerySubscriber();
+
+        $this->container
+            ->expects($this->exactly(3))
+            ->method('get')
+            ->with($service)
+            ->willReturn($subscriber)
+        ;
+
+        $this->locator->registerSubscriberService($service, get_class($subscriber));
+
+        $handler = $this->locator->findHandler(new ContactByIdentity());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByIdentity'], $handler);
+
+        // double call ContainerInterface::get()
+        $handler = $this->locator->findHandler(new ContactByIdentity());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByIdentity'], $handler);
+
+        $handler = $this->locator->findHandler(new ContactByNameQuery());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByNameQuery'], $handler);
     }
 }

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -43,14 +43,14 @@ class ContainerQueryHandlerLocatorTest extends TestCase
     protected function setUp(): void
     {
         $this->query = $this->createMock(Query::class);
-        $this->handler = function (Query $query) {
+        $this->handler = function (Query $query): void {
             $this->assertEquals($query, $this->query);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new ContainerQueryHandlerLocator($this->container);
     }
 
-    public function testFindHandler()
+    public function testFindHandler(): void
     {
         $service = 'foo';
 
@@ -71,7 +71,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
         $this->assertEquals($this->handler, $handler);
     }
 
-    public function testFindHandlerServiceInvoke()
+    public function testFindHandlerServiceInvoke(): void
     {
         $service = 'foo';
         $query = new ContactByIdentity();
@@ -99,7 +99,7 @@ class ContainerQueryHandlerLocatorTest extends TestCase
         $this->assertEquals($query, $handler_obj->query());
     }
 
-    public function testNoQueryHandler()
+    public function testNoQueryHandler(): void
     {
         $service = 'foo';
 
@@ -116,13 +116,13 @@ class ContainerQueryHandlerLocatorTest extends TestCase
         $this->assertNull($handler);
     }
 
-    public function testNoAnyCommandHandler()
+    public function testNoAnyCommandHandler(): void
     {
         $handler = $this->locator->findHandler($this->query);
         $this->assertNull($handler);
     }
 
-    public function testHandlerIsNotAQueryHandler()
+    public function testHandlerIsNotAQueryHandler(): void
     {
         $service = 'foo';
 

--- a/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/ContainerQueryHandlerLocatorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
@@ -36,7 +36,7 @@ class DirectBindingQueryHandlerLocatorTest extends TestCase
     {
         $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
-            $this->assertEquals($query, $this->query);
+            $this->assertSame($query, $this->query);
         };
         $this->locator = new DirectBindingQueryHandlerLocator();
     }
@@ -46,7 +46,7 @@ class DirectBindingQueryHandlerLocatorTest extends TestCase
         $this->locator->registerHandler(get_class($this->query), $this->handler);
 
         $handler = $this->locator->findHandler($this->query);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testNoQueryHandler()

--- a/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
@@ -35,13 +35,13 @@ class DirectBindingQueryHandlerLocatorTest extends TestCase
     protected function setUp(): void
     {
         $this->query = $this->createMock(Query::class);
-        $this->handler = function (Query $query) {
+        $this->handler = function (Query $query): void {
             $this->assertEquals($query, $this->query);
         };
         $this->locator = new DirectBindingQueryHandlerLocator();
     }
 
-    public function testFindHandler()
+    public function testFindHandler(): void
     {
         $this->locator->registerHandler(get_class($this->query), $this->handler);
 
@@ -49,7 +49,7 @@ class DirectBindingQueryHandlerLocatorTest extends TestCase
         $this->assertEquals($this->handler, $handler);
     }
 
-    public function testNoQueryHandler()
+    public function testNoQueryHandler(): void
     {
         $this->locator->registerHandler('foo', $this->handler);
 

--- a/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
@@ -13,6 +13,9 @@ namespace GpsLab\Component\Tests\Query\Handler\Locator;
 
 use GpsLab\Component\Query\Handler\Locator\DirectBindingQueryHandlerLocator;
 use GpsLab\Component\Query\Query;
+use GpsLab\Component\Tests\Fixture\Query\ContactByIdentity;
+use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
+use GpsLab\Component\Tests\Fixture\Query\Handler\ContestQuerySubscriber;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -56,5 +59,25 @@ class DirectBindingQueryHandlerLocatorTest extends TestCase
 
         $handler = $this->locator->findHandler($this->query);
         $this->assertNull($handler);
+    }
+
+    public function testRegisterSubscriber(): void
+    {
+        $subscriber = new ContestQuerySubscriber();
+
+        $this->locator->registerSubscriber($subscriber);
+
+        $handler = $this->locator->findHandler(new ContactByIdentity());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByIdentity'], $handler);
+
+        // double call ContainerInterface::get()
+        $handler = $this->locator->findHandler(new ContactByIdentity());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByIdentity'], $handler);
+
+        $handler = $this->locator->findHandler(new ContactByNameQuery());
+        $this->assertIsCallable($handler);
+        $this->assertSame([$subscriber, 'getByNameQuery'], $handler);
     }
 }

--- a/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/DirectBindingQueryHandlerLocatorTest.php
@@ -12,12 +12,13 @@ namespace GpsLab\Component\Tests\Query\Handler\Locator;
 
 use GpsLab\Component\Query\Handler\Locator\DirectBindingQueryHandlerLocator;
 use GpsLab\Component\Query\Query;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class DirectBindingQueryHandlerLocatorTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Query
+     * @var MockObject|Query
      */
     private $query;
 
@@ -31,13 +32,12 @@ class DirectBindingQueryHandlerLocatorTest extends TestCase
      */
     private $locator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->query = $this->getMock(Query::class);
+        $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
             $this->assertEquals($query, $this->query);
         };
-
         $this->locator = new DirectBindingQueryHandlerLocator();
     }
 

--- a/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
@@ -44,7 +44,7 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
     {
         $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
-            $this->assertEquals($query, $this->query);
+            $this->assertSame($query, $this->query);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new SymfonyContainerQueryHandlerLocator();
@@ -65,11 +65,11 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
         $this->locator->registerService(get_class($this->query), $service);
 
         $handler = $this->locator->findHandler($this->query);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($this->query);
-        $this->assertEquals($this->handler, $handler);
+        $this->assertSame($this->handler, $handler);
     }
 
     public function testFindHandlerServiceInvoke()
@@ -90,15 +90,15 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
         $this->locator->registerService(ContactByNameQuery::class, $service, $method);
 
         $handler = $this->locator->findHandler($query);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // double call ContainerInterface::get()
         $handler = $this->locator->findHandler($query);
-        $this->assertEquals([$handler_obj, $method], $handler);
+        $this->assertSame([$handler_obj, $method], $handler);
 
         // test exec handler
         call_user_func($handler, $query);
-        $this->assertEquals($query, $handler_obj->query());
+        $this->assertSame($query, $handler_obj->query());
     }
 
     public function testNoQueryHandler()

--- a/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
@@ -43,14 +43,14 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
     protected function setUp(): void
     {
         $this->query = $this->createMock(Query::class);
-        $this->handler = function (Query $query) {
+        $this->handler = function (Query $query): void {
             $this->assertEquals($query, $this->query);
         };
         $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new SymfonyContainerQueryHandlerLocator();
     }
 
-    public function testFindHandler()
+    public function testFindHandler(): void
     {
         $this->locator->setContainer($this->container);
         $service = 'foo';
@@ -72,7 +72,7 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
         $this->assertEquals($this->handler, $handler);
     }
 
-    public function testFindHandlerServiceInvoke()
+    public function testFindHandlerServiceInvoke(): void
     {
         $this->locator->setContainer($this->container);
         $service = 'foo';
@@ -97,11 +97,11 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
         $this->assertEquals([$handler_obj, $method], $handler);
 
         // test exec handler
-        call_user_func($handler, $query);
+        $handler($query);
         $this->assertEquals($query, $handler_obj->query());
     }
 
-    public function testNoQueryHandler()
+    public function testNoQueryHandler(): void
     {
         $this->locator->setContainer($this->container);
         $service = 'foo';
@@ -119,7 +119,7 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
         $this->assertNull($handler);
     }
 
-    public function testHandlerIsNotAQueryHandler()
+    public function testHandlerIsNotAQueryHandler(): void
     {
         $this->locator->setContainer($this->container);
         $service = 'foo';
@@ -137,14 +137,14 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
         $this->assertNull($handler);
     }
 
-    public function testNoAnyCommandHandler()
+    public function testNoAnyCommandHandler(): void
     {
         $this->locator->setContainer($this->container);
         $handler = $this->locator->findHandler($this->query);
         $this->assertNull($handler);
     }
 
-    public function testNoContainer()
+    public function testNoContainer(): void
     {
         $service = 'foo';
 

--- a/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
@@ -59,7 +59,7 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
             ->expects($this->exactly(2))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue($this->handler))
+            ->willReturn($this->handler)
         ;
 
         $this->locator->registerService(get_class($this->query), $service);
@@ -84,7 +84,7 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
             ->expects($this->exactly(2))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue($handler_obj))
+            ->willReturn($handler_obj)
         ;
 
         $this->locator->registerService(ContactByNameQuery::class, $service, $method);
@@ -110,7 +110,7 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
             ->expects($this->exactly(1))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue(null))
+            ->willReturn(null)
         ;
 
         $this->locator->registerService(get_class($this->query), $service);
@@ -128,7 +128,7 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
             ->expects($this->exactly(1))
             ->method('get')
             ->with($service)
-            ->will($this->returnValue(new \stdClass()))
+            ->willReturn(new \stdClass())
         ;
 
         $this->locator->registerService(get_class($this->query), $service);

--- a/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
@@ -107,7 +107,7 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
         $service = 'foo';
 
         $this->container
-            ->expects($this->exactly(1))
+            ->expects($this->once())
             ->method('get')
             ->with($service)
             ->will($this->returnValue(null))
@@ -125,7 +125,7 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
         $service = 'foo';
 
         $this->container
-            ->expects($this->exactly(1))
+            ->expects($this->once())
             ->method('get')
             ->with($service)
             ->will($this->returnValue(new \stdClass()))

--- a/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
@@ -14,9 +14,9 @@ use GpsLab\Component\Query\Handler\Locator\SymfonyContainerQueryHandlerLocator;
 use GpsLab\Component\Query\Query;
 use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContactByNameHandler;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class SymfonyContainerQueryHandlerLocatorTest extends TestCase
 {

--- a/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * GpsLab component.

--- a/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
+++ b/tests/Query/Handler/Locator/SymfonyContainerQueryHandlerLocatorTest.php
@@ -15,17 +15,18 @@ use GpsLab\Component\Query\Query;
 use GpsLab\Component\Tests\Fixture\Query\ContactByNameQuery;
 use GpsLab\Component\Tests\Fixture\Query\Handler\ContactByNameHandler;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SymfonyContainerQueryHandlerLocatorTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface
+     * @var MockObject|ContainerInterface
      */
     private $container;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Query
+     * @var MockObject|Query
      */
     private $query;
 
@@ -39,14 +40,13 @@ class SymfonyContainerQueryHandlerLocatorTest extends TestCase
      */
     private $locator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->query = $this->getMock(Query::class);
+        $this->query = $this->createMock(Query::class);
         $this->handler = function (Query $query) {
             $this->assertEquals($query, $this->query);
         };
-        $this->container = $this->getMock(ContainerInterface::class);
-
+        $this->container = $this->createMock(ContainerInterface::class);
         $this->locator = new SymfonyContainerQueryHandlerLocator();
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 $file = __DIR__.'/../vendor/autoload.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,7 @@
  * @copyright Copyright (c) 2011, Peter Gribanov
  * @license   http://opensource.org/licenses/MIT
  */
+
 $file = __DIR__.'/../vendor/autoload.php';
 
 if (!file_exists($file)) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,13 +1,5 @@
 <?php
 
-/**
- * GpsLab component.
- *
- * @author    Peter Gribanov <info@peter-gribanov.ru>
- * @copyright Copyright (c) 2011, Peter Gribanov
- * @license   http://opensource.org/licenses/MIT
- */
-
 $file = __DIR__.'/../vendor/autoload.php';
 
 if (!file_exists($file)) {


### PR DESCRIPTION
Release **Changelog** (since [`1.2.1...2.0.0`](https://github.com/gpslab/cqrs/compare/v1.2.1...v2.0.0))

* feature #22 Test with Symfony 3.4, 4.4, 5.0 (@peter-gribanov)
* feature #21 Test failed deserialize (@peter-gribanov)
* bug #20 PHPStan level 7 (@peter-gribanov)
* feature #19 Use phar of Scrutinizer CI and PHP Coveralls (@peter-gribanov)
* bug #18 Fix missing iterable value type for PHPStan (@peter-gribanov)
* feature #17 Require PHPStan for Static Analysis PHP (@peter-gribanov)
* feature #16 Copy simple usage docs in main `README.md` (@peter-gribanov)
* bug #15 Update 2.0 from master (@peter-gribanov)
* feature #12 Add Command and Query subscribers (@peter-gribanov)
* bug #10 Copy rules from PHP CS Fixer to Style CI config (@peter-gribanov)
* feature #9 Declare strict types (@peter-gribanov)
* feature #8 Change PHP-CS-Fixer rules (@peter-gribanov)
* bug #7 Not use a `call_user_func()` function (@peter-gribanov)
* feature #6 Declare type hinting (@peter-gribanov)
* bug #5 Optimize use `assert*()` method in tests (@peter-gribanov)
* bug #4 Optimize use `will*` methods (@peter-gribanov)
* bug #3 Change `$this->exactly(1)` to `$this->once()` (@peter-gribanov)
* feature #2 Add PHP 7.4 version test (@peter279k)